### PR TITLE
feat(p2p)!: channel-based recv and CancellationToken shutdown

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,9 +36,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/prevent-upstream-pr.yml
+++ b/.github/workflows/prevent-upstream-pr.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check-pr-target:
     runs-on: ubuntu-latest
-    if: github.repository == 'dirvine/ant-quic'
+    if: github.repository == 'dirvine/ant-quic' || github.repository == 'saorsa-labs/ant-quic'
     steps:
       - name: Check PR Target
         run: |
@@ -21,10 +21,10 @@ jobs:
             echo "❌ ERROR: This PR targets quinn-rs/quinn!"
             echo ""
             echo "ant-quic is NOT a fork of Quinn - it's an independent project."
-            echo "PRs should target dirvine/ant-quic only."
+            echo "PRs should target saorsa-labs/ant-quic only."
             echo ""
             echo "Please close this PR and create a new one targeting:"
-            echo "  https://github.com/dirvine/ant-quic"
+            echo "  https://github.com/saorsa-labs/ant-quic"
             exit 1
           fi
 

--- a/src/bin/ant-quic.rs
+++ b/src/bin/ant-quic.rs
@@ -39,13 +39,11 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
-
-/// Interval between shutdown flag checks in async select! branches (ms)
-const SHUTDOWN_POLL_INTERVAL_MS: u64 = 50;
 
 /// Default bootstrap nodes operated by Saorsa Labs
 ///
@@ -399,7 +397,7 @@ async fn main() -> anyhow::Result<()> {
     info!("═══════════════════════════════════════════════════════════════");
 
     // Setup shutdown signal
-    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown = CancellationToken::new();
     let shutdown_clone = shutdown.clone();
 
     tokio::spawn(async move {
@@ -407,7 +405,7 @@ async fn main() -> anyhow::Result<()> {
             error!("Failed to listen for ctrl-c: {}", e);
         }
         info!("Shutdown signal received");
-        shutdown_clone.store(true, Ordering::SeqCst);
+        shutdown_clone.cancel();
     });
 
     // Setup statistics
@@ -430,7 +428,7 @@ async fn main() -> anyhow::Result<()> {
 
     let event_handle = tokio::spawn(async move {
         let mut events = endpoint_clone.subscribe();
-        while !shutdown_events.load(Ordering::SeqCst) {
+        while !shutdown_events.is_cancelled() {
             match tokio::time::timeout(Duration::from_millis(100), events.recv()).await {
                 Ok(Ok(event)) => {
                     handle_event_with_state(
@@ -458,7 +456,7 @@ async fn main() -> anyhow::Result<()> {
 
         Some(tokio::spawn(async move {
             let mut interval_timer = tokio::time::interval(Duration::from_secs(interval));
-            while !shutdown_stats.load(Ordering::SeqCst) {
+            while !shutdown_stats.is_cancelled() {
                 interval_timer.tick().await;
                 print_stats(&endpoint_stats, &stats_clone2, json).await;
             }
@@ -498,7 +496,7 @@ async fn main() -> anyhow::Result<()> {
             let mut prev_bytes: u64 = 0;
             let mut prev_time = Instant::now();
 
-            while !shutdown_metrics.load(Ordering::SeqCst) {
+            while !shutdown_metrics.is_cancelled() {
                 interval.tick().await;
 
                 let report = build_metrics_report(
@@ -549,7 +547,7 @@ async fn main() -> anyhow::Result<()> {
             let mut counter: u64 = 0;
             let mut interval = tokio::time::interval(Duration::from_millis(interval_ms));
 
-            while !shutdown_counter.load(Ordering::SeqCst) {
+            while !shutdown_counter.is_cancelled() {
                 interval.tick().await;
                 counter += 1;
 
@@ -599,11 +597,7 @@ async fn main() -> anyhow::Result<()> {
             loop {
                 let result = tokio::select! {
                     r = endpoint_echo.recv() => r,
-                    _ = async {
-                        while !shutdown_echo.load(Ordering::SeqCst) {
-                            tokio::time::sleep(Duration::from_millis(SHUTDOWN_POLL_INTERVAL_MS)).await;
-                        }
-                    } => break,
+                    _ = shutdown_echo.cancelled() => break,
                 };
                 match result {
                     Ok((peer_id, data)) => {
@@ -746,7 +740,7 @@ async fn main() -> anyhow::Result<()> {
     info!("Ready. Press Ctrl+C to shutdown.");
 
     // All nodes are symmetric - accept connections while running
-    while !shutdown.load(Ordering::SeqCst) {
+    while !shutdown.is_cancelled() {
         if let Some(max_duration) = duration {
             if start_time.elapsed() > max_duration {
                 info!("Duration limit reached");
@@ -774,7 +768,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Shutdown
     info!("Shutting down...");
-    shutdown.store(true, Ordering::SeqCst);
+    shutdown.cancel();
 
     endpoint.shutdown().await;
     event_handle.abort();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -577,6 +577,11 @@ pub(crate) use web_time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 // Useful internal constants
 //
 
+/// Maximum time to wait for QUIC connections and tasks to drain during shutdown.
+///
+/// Used by both `P2pEndpoint` and `NatTraversalEndpoint` to bound graceful-shutdown waits.
+pub const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// The maximum number of CIDs we bother to issue per connection
 pub(crate) const LOC_CID_COUNT: u64 = 8;
 pub(crate) const RESET_TOKEN_SIZE: usize = 16;

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -1923,6 +1923,19 @@ impl NatTraversalEndpoint {
         self.constrained_event_rx.lock().try_recv().ok()
     }
 
+    /// Receive a constrained engine event asynchronously
+    ///
+    /// Waits for the next event from constrained transports (BLE/LoRa) without polling.
+    /// This eliminates the need for polling loops with sleep intervals.
+    ///
+    /// # Returns
+    ///
+    /// - `Some(event)` - An event with the data and source transport address
+    /// - `None` - The channel has been closed
+    pub async fn recv_constrained_event(&self) -> Option<ConstrainedEventWithAddr> {
+        self.constrained_event_rx.lock().recv().await
+    }
+
     /// Get a reference to the constrained event sender for testing
     ///
     /// This is primarily used for testing to inject events.

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -17,7 +17,9 @@ use std::{fmt, net::SocketAddr, sync::Arc, time::Duration};
 use crate::constrained::{ConstrainedEngine, EngineConfig, EngineEvent};
 use crate::transport::TransportRegistry;
 
-/// Maximum time to wait for QUIC connections to drain during shutdown
+/// Maximum time to wait for QUIC connections to drain during shutdown.
+///
+/// Shared with `SHUTDOWN_TIMEOUT_SECS` in `p2p_endpoint` — keep in sync.
 const SHUTDOWN_DRAIN_TIMEOUT_SECS: u64 = 5;
 
 /// Creates a bind address that allows the OS to select a random available port
@@ -4036,12 +4038,21 @@ impl NatTraversalEndpoint {
                 "Waiting for {} transport listener tasks to complete",
                 handles.len()
             );
-            for handle in handles {
-                if let Err(e) = handle.await {
-                    warn!("Transport listener task failed during shutdown: {}", e);
-                }
+            match tokio::time::timeout(
+                Duration::from_secs(SHUTDOWN_DRAIN_TIMEOUT_SECS),
+                async {
+                    for handle in handles {
+                        if let Err(e) = handle.await {
+                            warn!("Transport listener task failed during shutdown: {e}");
+                        }
+                    }
+                },
+            )
+            .await
+            {
+                Ok(()) => debug!("All transport listener tasks completed"),
+                Err(_) => warn!("Transport listener tasks timed out during shutdown, proceeding"),
             }
-            debug!("All transport listener tasks completed");
         }
 
         info!("NAT traversal endpoint shutdown completed");

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -17,6 +17,9 @@ use std::{fmt, net::SocketAddr, sync::Arc, time::Duration};
 use crate::constrained::{ConstrainedEngine, EngineConfig, EngineEvent};
 use crate::transport::TransportRegistry;
 
+/// Maximum time to wait for QUIC connections to drain during shutdown
+const SHUTDOWN_DRAIN_TIMEOUT_SECS: u64 = 5;
+
 /// Creates a bind address that allows the OS to select a random available port
 ///
 /// This provides protocol obfuscation by preventing port fingerprinting, which improves
@@ -4008,9 +4011,18 @@ impl NatTraversalEndpoint {
             }
         }
 
-        // Wait for connection to be closed
+        // Bounded drain: in simultaneous-shutdown scenarios both sides may
+        // close at once, so wait_idle can stall until the idle timeout.
         if let Some(ref endpoint) = self.inner_endpoint {
-            endpoint.wait_idle().await;
+            if tokio::time::timeout(
+                Duration::from_secs(SHUTDOWN_DRAIN_TIMEOUT_SECS),
+                endpoint.wait_idle(),
+            )
+            .await
+            .is_err()
+            {
+                info!("wait_idle timed out during shutdown, proceeding");
+            }
         }
 
         // Wait for transport listener tasks to complete

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -17,10 +17,7 @@ use std::{fmt, net::SocketAddr, sync::Arc, time::Duration};
 use crate::constrained::{ConstrainedEngine, EngineConfig, EngineEvent};
 use crate::transport::TransportRegistry;
 
-/// Maximum time to wait for QUIC connections to drain during shutdown.
-///
-/// Shared with `SHUTDOWN_TIMEOUT_SECS` in `p2p_endpoint` — keep in sync.
-const SHUTDOWN_DRAIN_TIMEOUT_SECS: u64 = 5;
+use crate::SHUTDOWN_DRAIN_TIMEOUT;
 
 /// Creates a bind address that allows the OS to select a random available port
 ///
@@ -4016,12 +4013,9 @@ impl NatTraversalEndpoint {
         // Bounded drain: in simultaneous-shutdown scenarios both sides may
         // close at once, so wait_idle can stall until the idle timeout.
         if let Some(ref endpoint) = self.inner_endpoint {
-            if tokio::time::timeout(
-                Duration::from_secs(SHUTDOWN_DRAIN_TIMEOUT_SECS),
-                endpoint.wait_idle(),
-            )
-            .await
-            .is_err()
+            if tokio::time::timeout(SHUTDOWN_DRAIN_TIMEOUT, endpoint.wait_idle())
+                .await
+                .is_err()
             {
                 info!("wait_idle timed out during shutdown, proceeding");
             }
@@ -4038,16 +4032,13 @@ impl NatTraversalEndpoint {
                 "Waiting for {} transport listener tasks to complete",
                 handles.len()
             );
-            match tokio::time::timeout(
-                Duration::from_secs(SHUTDOWN_DRAIN_TIMEOUT_SECS),
-                async {
-                    for handle in handles {
-                        if let Err(e) = handle.await {
-                            warn!("Transport listener task failed during shutdown: {e}");
-                        }
+            match tokio::time::timeout(SHUTDOWN_DRAIN_TIMEOUT, async {
+                for handle in handles {
+                    if let Err(e) = handle.await {
+                        warn!("Transport listener task failed during shutdown: {e}");
                     }
-                },
-            )
+                }
+            })
             .await
             {
                 Ok(()) => debug!("All transport listener tasks completed"),

--- a/src/node.rs
+++ b/src/node.rs
@@ -519,8 +519,8 @@ impl Node {
     }
 
     /// Receive data from any peer
-    pub async fn recv(&self, timeout: Duration) -> Result<(PeerId, Vec<u8>), NodeError> {
-        self.inner.recv(timeout).await.map_err(NodeError::Endpoint)
+    pub async fn recv(&self) -> Result<(PeerId, Vec<u8>), NodeError> {
+        self.inner.recv().await.map_err(NodeError::Endpoint)
     }
 
     // === Observability ===

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -92,7 +92,9 @@ const MAX_UNI_STREAM_READ_BYTES: usize = 1024 * 1024;
 /// Sleep interval for the constrained transport poller when idle (ms)
 const CONSTRAINED_POLL_INTERVAL_MS: u64 = 1;
 
-/// Maximum time to wait for graceful shutdown of the inner endpoint
+/// Maximum time to wait for graceful shutdown of the inner endpoint.
+///
+/// Shared with `SHUTDOWN_DRAIN_TIMEOUT_SECS` in `nat_traversal_api` — keep in sync.
 const SHUTDOWN_TIMEOUT_SECS: u64 = 5;
 
 /// Derive a synthetic PeerId by hashing a `TransportAddr` display string.
@@ -2063,14 +2065,15 @@ impl P2pEndpoint {
         }
 
         // Bounded timeout prevents blocking when the remote peer is unresponsive.
-        if timeout(
+        match timeout(
             Duration::from_secs(SHUTDOWN_TIMEOUT_SECS),
             self.inner.shutdown(),
         )
         .await
-        .is_err()
         {
-            warn!("Inner endpoint shutdown timed out, proceeding");
+            Err(_) => warn!("Inner endpoint shutdown timed out, proceeding"),
+            Ok(Err(e)) => warn!("Inner endpoint shutdown error: {e}"),
+            Ok(Ok(())) => {}
         }
     }
 

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -83,9 +83,6 @@ use crate::unified_config::P2pConfig;
 /// Event channel capacity
 const EVENT_CHANNEL_CAPACITY: usize = 256;
 
-/// Capacity of the data channel shared between background reader tasks and recv()
-const DATA_CHANNEL_CAPACITY: usize = 256;
-
 /// Maximum payload size for a single uni stream read (1 MB)
 const MAX_UNI_STREAM_READ_BYTES: usize = 1024 * 1024;
 
@@ -659,7 +656,7 @@ impl P2pEndpoint {
         router.set_quic_endpoint(Arc::clone(&inner_arc));
 
         // Create channel for data received from background reader tasks
-        let (data_tx, data_rx) = mpsc::channel(DATA_CHANNEL_CAPACITY);
+        let (data_tx, data_rx) = mpsc::channel(config.data_channel_capacity);
         let reader_tasks = Arc::new(tokio::sync::Mutex::new(tokio::task::JoinSet::new()));
         let reader_handles = Arc::new(RwLock::new(HashMap::new()));
 

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -90,7 +90,7 @@ const DATA_CHANNEL_CAPACITY: usize = 256;
 const MAX_UNI_STREAM_READ_BYTES: usize = 1024 * 1024;
 
 /// Sleep interval for the constrained transport poller when idle (ms)
-const CONSTRAINED_POLL_INTERVAL_MS: u64 = 1;
+const CONSTRAINED_POLL_INTERVAL_MS: u64 = 100;
 
 use crate::SHUTDOWN_DRAIN_TIMEOUT;
 

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -86,9 +86,6 @@ const EVENT_CHANNEL_CAPACITY: usize = 256;
 /// Maximum payload size for a single uni stream read (1 MB)
 const MAX_UNI_STREAM_READ_BYTES: usize = 1024 * 1024;
 
-/// Sleep interval for the constrained transport poller when idle (ms)
-const CONSTRAINED_POLL_INTERVAL_MS: u64 = 100;
-
 use crate::SHUTDOWN_DRAIN_TIMEOUT;
 
 /// Derive a synthetic PeerId by hashing a `TransportAddr` display string.

--- a/tests/comprehensive_p2p_network.rs
+++ b/tests/comprehensive_p2p_network.rs
@@ -999,9 +999,8 @@ mod channel_recv_and_shutdown_tests {
 
         // Spawn server accept so handshake completes and reader task is spawned
         let server_clone = server.clone();
-        let accept_handle = tokio::spawn(async move {
-            timeout(SHORT_TIMEOUT, server_clone.accept()).await
-        });
+        let accept_handle =
+            tokio::spawn(async move { timeout(SHORT_TIMEOUT, server_clone.accept()).await });
 
         tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -1012,7 +1011,10 @@ mod channel_recv_and_shutdown_tests {
         let peer_conn = match connect_result {
             Ok(Ok(pc)) => pc,
             other => {
-                println!("Connection not established ({:?}), skipping recv test", other.err());
+                println!(
+                    "Connection not established ({:?}), skipping recv test",
+                    other.err()
+                );
                 accept_handle.abort();
                 shutdown_with_timeout(client).await;
                 shutdown_with_timeout(server).await;
@@ -1029,7 +1031,10 @@ mod channel_recv_and_shutdown_tests {
         match send_result {
             Ok(Ok(())) => println!("Data sent successfully"),
             other => {
-                println!("Send did not succeed ({:?}), skipping recv assertion", other.err());
+                println!(
+                    "Send did not succeed ({:?}), skipping recv assertion",
+                    other.err()
+                );
                 shutdown_with_timeout(client).await;
                 shutdown_with_timeout(server).await;
                 return;
@@ -1083,10 +1088,7 @@ mod channel_recv_and_shutdown_tests {
         let deadline = Duration::from_secs(1);
         match timeout(deadline, accept_handle).await {
             Ok(Ok(result)) => {
-                assert!(
-                    result.is_none(),
-                    "accept() should return None on shutdown"
-                );
+                assert!(result.is_none(), "accept() should return None on shutdown");
                 println!("accept() returned None promptly after shutdown");
             }
             Ok(Err(e)) => {
@@ -1113,9 +1115,8 @@ mod channel_recv_and_shutdown_tests {
 
         // Spawn accept so handshake can complete
         let server_clone = server.clone();
-        let accept_handle = tokio::spawn(async move {
-            timeout(SHORT_TIMEOUT, server_clone.accept()).await
-        });
+        let accept_handle =
+            tokio::spawn(async move { timeout(SHORT_TIMEOUT, server_clone.accept()).await });
 
         tokio::time::sleep(Duration::from_millis(100)).await;
 


### PR DESCRIPTION
## Summary

- Replace poll-based `recv()` with channel-based architecture using background reader tasks and a shared `mpsc` channel, eliminating O(n×timeout) peer iteration
- Replace `AtomicBool` shutdown flags with `CancellationToken` across `P2pEndpoint`, `ant-quic` binary, and `e2e-test-node` binary
- Race `accept()` against the shutdown token so it returns promptly on shutdown
- Bound `wait_idle` and transport-listener drain with timeouts to prevent shutdown stalls
- Unify duplicated shutdown timeout constants into a single `SHUTDOWN_DRAIN_TIMEOUT` in `lib.rs`
- Document `DefaultHasher` stability assumptions on synthetic PeerId functions

## Test plan

- [ ] `cargo test` passes (580+ tests)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean
- [ ] Manual test: run `ant-quic` binary, verify Ctrl+C shuts down promptly
- [ ] Manual test: connect two nodes, verify `recv()` delivers data without polling delays

🤖 Generated with [Claude Code](https://claude.com/claude-code)