### PR TITLE
perf: replace all polling loops with async event-driven mechanisms

### DIFF
--- a/src/candidate_discovery.rs
+++ b/src/candidate_discovery.rs
@@ -715,10 +715,10 @@ impl CandidateDiscoveryManager {
                 return Ok(candidates);
             }
 
-            // Yield to other threads briefly. Local interface enumeration is a
-            // single syscall (getifaddrs on Unix) and should complete nearly
-            // instantly, so we only need to yield rather than sleep.
-            std::thread::yield_now();
+            // Brief sleep to avoid busy-waiting while scan completes.
+            // Although getifaddrs is fast, in edge cases check_scan_complete()
+            // may return None for up to 2s, so we throttle to avoid CPU burn.
+            std::thread::sleep(Duration::from_millis(10));
         }
     }
 

--- a/src/candidate_discovery.rs
+++ b/src/candidate_discovery.rs
@@ -715,8 +715,10 @@ impl CandidateDiscoveryManager {
                 return Ok(candidates);
             }
 
-            // Small sleep to avoid busy waiting
-            std::thread::sleep(Duration::from_millis(10));
+            // Yield to other threads briefly. Local interface enumeration is a
+            // single syscall (getifaddrs on Unix) and should complete nearly
+            // instantly, so we only need to yield rather than sleep.
+            std::thread::yield_now();
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace 6 production polling/sleep loops across 3 files with proper async event-driven patterns
- Add `shutdown_notify` field to `NatTraversalEndpoint` for instant transport listener shutdown (was 100ms polling)
- Add `connection_notify()` accessor so `P2pEndpoint` can await connection events instead of 50ms sleep loops
- Replace 10ms discovery polling with deadline-aware sleep that respects overall timeout
- Replace `thread::sleep(10ms)` with `thread::yield_now()` in candidate discovery (single syscall)

## Changes

| File | Fix | Before | After |
|------|-----|--------|-------|
| `nat_traversal_api.rs` | Transport listener shutdown (2x) | 100ms `AtomicBool` polling loop | `shutdown_notify.notified()` |
| `nat_traversal_api.rs` | Discovery polling | Fixed 10ms sleep | Deadline-aware `sleep(remaining.min(10ms))` |
| `p2p_endpoint.rs` | `connect_to_peer()` | 50ms sleep loop | `tokio::select!` on notify/shutdown/timeout |
| `p2p_endpoint.rs` | `try_hole_punch()` | 50ms sleep loop | `tokio::select!` on notify/shutdown/timeout |
| `candidate_discovery.rs` | Local interface scan | 10ms `thread::sleep` | `thread::yield_now()` |

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` zero warnings
- [x] `cargo test --lib` 1403 passed, 0 failed
- [ ] CI workflows green

🤖 Generated with [Claude Code](https://claude.com/claude-code)