### PR TITLE
fix(transport): resolve #163, #164, #166 — cooperative reader cancel + scope-filter NAT candidates

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -270,7 +270,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high
           license-check: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.13] - 2026-04-17
+
+### Fixed
+
+- **#166 — `Node::send` succeeded, `Node::recv` silently dropped data in a multi-peer mesh.** `P2pEndpoint::spawn_reader_task` previously aborted the previous reader for a peer whenever a redundant connection was established (simultaneous-open under mesh churn). The abort could fire between `accept_uni()` returning a `RecvStream` and `read_to_end()` completing, cancelling the reader mid-read and silently dropping bytes that QUIC had already ACKed to the sender. The reader now uses a `CancellationToken` honored only at the `accept_uni()` boundary — in-flight reads always finish and forward their bytes before the task exits. Reader handles are stored per-peer as a `Vec<ReaderTaskHandle>` so multiple concurrent connections to the same peer each run their own reader until their underlying QUIC connection terminates. Peer-wide cleanup now fires only when the last reader for that peer exits. New regression test `tests/regression_166_mesh_churn.rs` reproduces the original bug (0 / 240 streams delivered, 90 s timeout) and validates the fix (240 / 240 delivered, < 7 s).
+- **#163 — NAT traversal fired on public-IP peers, hole-punch success rate 0 % on bootstrap mesh.** `CoordinationAccepted` previously accepted RFC1918, link-local, ULA, and loopback addresses into the NAT-traversal candidate set, causing hole-punch probes against private addresses visible only inside the peer's LAN. `connect_orchestrated` likewise dialed leaked private candidates and stalled for the full QUIC handshake timeout per entry (~50 s). Two new helpers, `drop_non_global_nat_candidates_when_global_present` and `drop_non_global_direct_candidates_when_global_present`, strip non-Global entries from both paths whenever at least one Global-scope candidate is available, while preserving pure-LAN peer lists so mDNS-discovered neighbours remain dialable. Four new unit tests cover the filter on mixed and LAN-only inputs.
+
+### Tests
+
+- **#164 — relay `bytes_forwarded=0` regression gate.** Added `test_handle_client_datagram_records_bytes_and_datagram_count` driving `handle_client_datagram` end-to-end with an uncompressed datagram and asserting `stats.total_bytes_relayed` and `stats.datagrams_forwarded` both advance. Locks in the observability wiring landed in 0.26.10/0.26.11 against future regressions.
+- **Release gate**: `cargo fmt --all -- --check`, `cargo clippy --all-features --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`, and `cargo nextest run --all-features --workspace` (2240/2240 passed) all green on the fix commit.
+
 ## [0.26.12] - 2026-04-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ant-quic"
-version = "0.26.12"
+version = "0.26.13"
 dependencies = [
  "ant-quic-workspace-hack",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "ant-quic"
-version = "0.26.12"
+version = "0.26.13"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/src/masque/relay_server.rs
+++ b/src/masque/relay_server.rs
@@ -1442,6 +1442,68 @@ mod tests {
         assert_eq!(stats.sessions_created.load(Ordering::Relaxed), 1);
     }
 
+    /// Regression for issue #164.
+    ///
+    /// `bytes_relayed` / `datagrams_forwarded` must increment each time the
+    /// relay forwards a client datagram. The original bug showed
+    /// `is_relaying: true` with `bytes_forwarded: 0` across every VPS in a
+    /// long-running mesh. We cover the datagram accounting path end-to-end
+    /// by driving `handle_client_datagram` with an uncompressed datagram
+    /// whose target is carried in-line and asserting both counters advance
+    /// by the encoded payload length.
+    #[tokio::test]
+    async fn test_handle_client_datagram_records_bytes_and_datagram_count() {
+        use crate::VarInt;
+        use crate::masque::{Datagram, UncompressedDatagram};
+        use bytes::Bytes;
+
+        let config = MasqueRelayConfig::default();
+        let server = MasqueRelayServer::new(config, test_addr(9000));
+        let client = client_addr(42);
+
+        server
+            .handle_connect_request(&ConnectUdpRequest::bind_any(), client)
+            .await
+            .unwrap();
+
+        let target: SocketAddr = "203.0.113.77:4444".parse().unwrap();
+        let payload = Bytes::from_static(b"PROBE0123456789-relay-forwarding-check");
+        let payload_len = payload.len() as u64;
+
+        // Uncompressed datagram carries the target in-line; session resolves
+        // it directly without needing a prior COMPRESSION_ASSIGN roundtrip.
+        let uncompressed = UncompressedDatagram::new(VarInt::from_u32(2), target, payload.clone());
+        let datagram = Datagram::from(uncompressed);
+
+        let result = server
+            .handle_client_datagram(client, datagram, payload)
+            .await;
+
+        match result {
+            DatagramResult::Forward(out) => {
+                assert_eq!(
+                    out.target, target,
+                    "forwarded datagram must address the peer target"
+                );
+            }
+            other => panic!(
+                "expected DatagramResult::Forward, got {other:?} — relay forwarding is broken"
+            ),
+        }
+
+        let stats = server.stats();
+        assert_eq!(
+            stats.total_bytes_relayed(),
+            payload_len,
+            "bytes_relayed must advance by the forwarded payload size (#164)"
+        );
+        assert_eq!(
+            stats.datagrams_forwarded.load(Ordering::Relaxed),
+            1,
+            "datagrams_forwarded must advance for each forwarded datagram (#164)"
+        );
+    }
+
     #[tokio::test]
     async fn test_get_session_info() {
         let config = MasqueRelayConfig::default();

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -510,7 +510,7 @@ pub struct NatTraversalConfig {
     /// windows are **not** derived from this value — they use transport-layer
     /// defaults based on bandwidth-delay products.
     ///
-    /// Default: [`P2pConfig::DEFAULT_MAX_MESSAGE_SIZE`] (4 MiB).
+    /// Default: [`crate::unified_config::P2pConfig::DEFAULT_MAX_MESSAGE_SIZE`] (4 MiB).
     #[serde(default = "default_max_message_size")]
     pub max_message_size: usize,
 
@@ -911,6 +911,29 @@ impl CandidateAddress {
             CandidateState::Removed => 0,
         }
     }
+}
+
+/// Drop non-Global NAT-traversal candidates when at least one Global-scope
+/// address is present (issue #163).
+///
+/// When a peer's `ADD_ADDRESS` / `CoordinationAccepted` payload leaks RFC1918,
+/// link-local, ULA, or loopback entries alongside its public address(es),
+/// running hole-punch probes against those private entries from an off-LAN
+/// peer stalls for the full NAT probe window and never produces a usable
+/// path. Keep non-globals only when the list has nothing better (e.g. pure
+/// LAN peers).
+fn drop_non_global_nat_candidates_when_global_present(addrs: &mut Vec<SocketAddr>) {
+    let has_global = addrs.iter().any(|addr| {
+        crate::reachability::socket_addr_scope(*addr)
+            == Some(crate::reachability::ReachabilityScope::Global)
+    });
+    if !has_global {
+        return;
+    }
+    addrs.retain(|addr| {
+        crate::reachability::socket_addr_scope(*addr)
+            == Some(crate::reachability::ReachabilityScope::Global)
+    });
 }
 
 fn allow_loopback_from_env() -> bool {
@@ -3456,6 +3479,14 @@ impl NatTraversalEndpoint {
                         .collect();
                     normalized_target_addrs.sort_unstable();
                     normalized_target_addrs.dedup();
+
+                    // Issue #163: drop non-Global candidates before they enter
+                    // the NAT-traversal session. See
+                    // `drop_non_global_nat_candidates_when_global_present` for
+                    // rationale.
+                    drop_non_global_nat_candidates_when_global_present(
+                        &mut normalized_target_addrs,
+                    );
 
                     if let Some(mut entry) = self.active_sessions.get_mut(target) {
                         let session = entry.value_mut();
@@ -8276,6 +8307,51 @@ mod tests {
         assert_eq!(config.max_candidates, 8);
         assert!(config.enable_symmetric_nat);
         assert!(config.enable_relay_fallback);
+    }
+
+    /// Regression for issue #163.
+    ///
+    /// A mixed list of Global + private/link-local/loopback candidates from
+    /// `CoordinationAccepted` must be stripped down to Global only before the
+    /// session fires hole-punch probes — otherwise we stall on RFC1918
+    /// entries (like `10.x.y.z`) that cannot be reached from an off-LAN
+    /// peer.
+    #[test]
+    fn test_drop_non_global_nat_candidates_filters_mixed_list() {
+        let private_v4: SocketAddr = "10.200.0.1:5483".parse().unwrap();
+        let global_v4: SocketAddr = "198.51.100.20:5483".parse().unwrap();
+        let global_v6: SocketAddr = "[2001:db8::20]:5483".parse().unwrap();
+        let link_local: SocketAddr = "169.254.10.1:5483".parse().unwrap();
+        let loopback: SocketAddr = "127.0.0.1:5483".parse().unwrap();
+        let ula_v6: SocketAddr = "[fc00::1]:5483".parse().unwrap();
+
+        let mut addrs = vec![
+            private_v4, link_local, loopback, ula_v6, global_v4, global_v6,
+        ];
+        drop_non_global_nat_candidates_when_global_present(&mut addrs);
+        addrs.sort();
+        let mut expected = vec![global_v4, global_v6];
+        expected.sort();
+        assert_eq!(
+            addrs, expected,
+            "private/link-local/loopback/ULA must be dropped when Global candidates are present"
+        );
+    }
+
+    /// The filter is a no-op on a purely non-global list so that pure-LAN
+    /// peers (e.g. mDNS-discovered `192.168.x` neighbours) remain dialable.
+    #[test]
+    fn test_drop_non_global_nat_candidates_preserves_lan_only() {
+        let private_v4: SocketAddr = "192.168.1.25:5483".parse().unwrap();
+        let link_local_v6: SocketAddr = "[fe80::1]:5483".parse().unwrap();
+
+        let original = vec![private_v4, link_local_v6];
+        let mut addrs = original.clone();
+        drop_non_global_nat_candidates_when_global_present(&mut addrs);
+        assert_eq!(
+            addrs, original,
+            "LAN-only candidate sets must not be emptied"
+        );
     }
 
     #[test]

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -121,7 +121,18 @@ struct PeerHintRecord {
 
 #[derive(Debug)]
 struct ReaderTaskHandle {
+    /// Monotonic id used by the reader-exit handler to locate the exiting task
+    /// within the per-peer vector. A peer may briefly have multiple live QUIC
+    /// connections (simultaneous-open races, coordinated + direct paths
+    /// converging); each has its own reader, uniquely identified by this id.
     generation: u64,
+    /// Cooperative shutdown signal. Honored at the `accept_uni()` boundary only,
+    /// so an in-flight `read_to_end()` always completes before the task exits.
+    /// This prevents silent loss of already-ACKed bytes during connection
+    /// replacement (issue #166).
+    cancel: CancellationToken,
+    /// Fallback abort handle used by `shutdown()` and as a backstop during
+    /// explicit `cleanup_connection` after cooperative cancellation.
     abort_handle: tokio::task::AbortHandle,
 }
 
@@ -164,6 +175,24 @@ fn direct_candidate_rank(addr: SocketAddr) -> (u8, u8) {
 fn prioritize_direct_candidate_addrs(addrs: &mut Vec<SocketAddr>) {
     addrs.sort_by_key(|addr| std::cmp::Reverse(direct_candidate_rank(*addr)));
     addrs.dedup();
+}
+
+/// Drop LocalNetwork / Loopback candidates from the dial list when at least one
+/// Global-scope address is present (issue #163).
+///
+/// When a peer advertises both globally-routable and private addresses (for
+/// example, a VPS whose interface scan leaked `10.x.y.z` alongside its public
+/// IP), dialing the private entries from an off-LAN caller stalls for the
+/// per-address QUIC handshake timeout before failing. Keep them only when the
+/// list contains nothing better so pure-LAN peers (e.g. discovered via mDNS)
+/// still work.
+fn drop_non_global_direct_candidates_when_global_present(addrs: &mut Vec<SocketAddr>) {
+    let has_global = addrs
+        .iter()
+        .any(|addr| socket_addr_scope(*addr) == Some(ReachabilityScope::Global));
+    if has_global {
+        addrs.retain(|addr| socket_addr_scope(*addr) == Some(ReachabilityScope::Global));
+    }
 }
 
 fn relay_target_rank(addr: SocketAddr) -> u8 {
@@ -366,11 +395,23 @@ pub struct P2pEndpoint {
     /// Channel receiver for data received from QUIC reader tasks and constrained poller
     data_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<(PeerId, Vec<u8>)>>>,
 
-    /// JoinSet tracking background reader tasks (each returns peer + generation on exit)
-    reader_tasks: Arc<tokio::sync::Mutex<tokio::task::JoinSet<(PeerId, u64)>>>,
+    /// JoinSet tracking background reader tasks.
+    ///
+    /// Each task returns `(peer_id, generation, conn_stable_id)` on exit so the
+    /// reader-exit handler can identify which `(peer_id, generation)` slot to
+    /// clear and include the stable connection id in diagnostics.
+    reader_tasks: Arc<tokio::sync::Mutex<tokio::task::JoinSet<(PeerId, u64, usize)>>>,
 
-    /// Per-peer abort handles for targeted reader task cancellation
-    reader_handles: Arc<RwLock<HashMap<PeerId, ReaderTaskHandle>>>,
+    /// Per-peer reader-task handles.
+    ///
+    /// Keyed on `PeerId` but stores a `Vec` because a single peer may briefly
+    /// have multiple live QUIC connections (simultaneous-open races, or the
+    /// coordinated and direct paths converging). Each entry is uniquely
+    /// identified by its `generation`. Readers are not pre-empted on
+    /// connection replacement — each runs until its own connection terminates,
+    /// so ACKed bytes in flight on the old connection are always delivered
+    /// (issue #166).
+    reader_handles: Arc<RwLock<HashMap<PeerId, Vec<ReaderTaskHandle>>>>,
 
     /// Monotonic generation counter for reader-task replacement.
     next_reader_generation: Arc<AtomicU64>,
@@ -886,7 +927,7 @@ pub enum EndpointError {
 async fn do_cleanup_connection(
     connected_peers: &RwLock<HashMap<PeerId, PeerConnection>>,
     inner: &NatTraversalEndpoint,
-    reader_handles: &RwLock<HashMap<PeerId, ReaderTaskHandle>>,
+    reader_handles: &RwLock<HashMap<PeerId, Vec<ReaderTaskHandle>>>,
     direct_path_statuses: &ParkingRwLock<HashMap<PeerId, DirectPathStatus>>,
     stats: &RwLock<EndpointStats>,
     event_tx: &broadcast::Sender<P2pEvent>,
@@ -898,9 +939,14 @@ async fn do_cleanup_connection(
     }
     direct_path_statuses.write().remove(peer_id);
 
-    // Abort the background reader task for this peer
-    if let Some(handle) = reader_handles.write().await.remove(peer_id) {
-        handle.abort_handle.abort();
+    // Tear down all background readers for this peer. Cooperative cancel first
+    // (allows any in-flight `read_to_end()` to complete and deliver its bytes),
+    // then `abort()` as a backstop in case a reader is wedged.
+    if let Some(handles) = reader_handles.write().await.remove(peer_id) {
+        for handle in handles {
+            handle.cancel.cancel();
+            handle.abort_handle.abort();
+        }
     }
 
     let removed = remove_connected_peer(connected_peers, stats, event_tx, peer_id, reason).await;
@@ -1932,6 +1978,7 @@ impl P2pEndpoint {
         }
 
         prioritize_direct_candidate_addrs(&mut explicit_addrs);
+        drop_non_global_direct_candidates_when_global_present(&mut explicit_addrs);
 
         if !explicit_addrs.is_empty() && !is_simple_address_only {
             match self
@@ -3178,9 +3225,10 @@ impl P2pEndpoint {
         // Do NOT re-fetch via get_connection() — see simultaneous-connect fix.
         let reader_conn = connection.clone();
 
-        // In simultaneous-open races, abort any previous reader for this peer
-        // before installing the replacement connection lifecycle.
-        self.abort_existing_reader_task(peer_id).await;
+        // No abort-old: under simultaneous-open, the previous connection may
+        // still carry ACKed-but-undrained bytes. Aborting its reader here would
+        // silently lose those bytes (issue #166). The old reader will exit on
+        // its own when its connection terminates or idles out.
 
         // Spawn connection handler (Client side - we initiated)
         self.inner
@@ -3620,9 +3668,10 @@ impl P2pEndpoint {
                 // QUIC connection (simultaneous-connect recv() hang).
                 let reader_conn = connection.clone();
 
-                // In simultaneous-open races, abort any previous reader for this peer
-                // before installing the replacement connection lifecycle.
-                self.abort_existing_reader_task(resolved_peer_id).await;
+                // No abort-old: see spawn_reader_task — the old connection may
+                // still carry undrained ACKed bytes (issue #166). Multiple
+                // concurrent readers per peer are tolerated; each exits when
+                // its own connection closes.
 
                 // They initiated the connection to us = Server side
                 if let Err(e) =
@@ -3666,7 +3715,8 @@ impl P2pEndpoint {
     /// This is the single point of cleanup for connections — it removes the peer from:
     /// - `connected_peers` HashMap
     /// - `NatTraversalEndpoint.connections` DashMap (via `remove_connection()`)
-    /// - `reader_handles` (aborts the background reader task)
+    /// - `reader_handles` (cooperative cancel + abort backstop on all readers
+    ///   for this peer)
     /// - Updates stats and emits a disconnect event
     ///
     /// Safe to call even if the peer is not in all structures (idempotent).
@@ -4554,18 +4604,20 @@ impl P2pEndpoint {
     /// Spawn a background tokio task that reads uni streams from a QUIC connection
     /// and forwards received data into the shared `data_tx` channel.
     ///
-    /// The task exits naturally when the connection is closed or the channel is dropped.
-    async fn abort_existing_reader_task(&self, peer_id: PeerId) {
-        let mut handles = self.reader_handles.write().await;
-        if let Some(old_handle) = handles.remove(&peer_id) {
-            tracing::debug!(
-                "Aborting previous reader task for peer {:?} before connection replacement",
-                peer_id
-            );
-            old_handle.abort_handle.abort();
-        }
-    }
-
+    /// # Multiple readers per peer (issue #166)
+    ///
+    /// A peer may briefly have two live QUIC connections (simultaneous-open,
+    /// coordinated + direct paths converging). Each connection gets its own
+    /// reader; readers are never pre-empted on connection replacement. They
+    /// exit when their own connection terminates or idles out.
+    ///
+    /// # Cooperative cancellation
+    ///
+    /// The reader honors a [`CancellationToken`] only at the `accept_uni()`
+    /// boundary. An in-flight `read_to_end()` (which drains already-ACKed bytes
+    /// that Quinn has buffered) is NEVER interrupted — this is the core
+    /// correctness property against issue #166. Explicit teardown
+    /// (`cleanup_connection`, `shutdown`) also calls `abort()` as a backstop.
     async fn spawn_reader_task(&self, peer_id: PeerId, connection: crate::high_level::Connection) {
         let data_tx = self.data_tx.clone();
         let connected_peers = Arc::clone(&self.connected_peers);
@@ -4573,35 +4625,58 @@ impl P2pEndpoint {
         let inner = Arc::clone(&self.inner);
         let max_read_bytes = self.config.max_message_size;
         let generation = self.next_reader_generation.fetch_add(1, Ordering::Relaxed);
+        let conn_stable_id = connection.stable_id();
+        let cancel = CancellationToken::new();
+        let reader_cancel = cancel.clone();
 
         let abort_handle = self.reader_tasks.lock().await.spawn(async move {
             loop {
-                // Accept the next unidirectional stream
-                let mut recv_stream = match connection.accept_uni().await {
-                    Ok(stream) => stream,
-                    Err(e) => {
+                // Cancel only between streams. If the token fires while we're
+                // mid-`read_to_end()`, the read completes first (Quinn already
+                // holds the ACKed bytes) and the NEXT iteration exits here.
+                let mut recv_stream = tokio::select! {
+                    biased;
+                    _ = reader_cancel.cancelled() => {
                         debug!(
-                            "Reader task for peer {:?} ending: accept_uni error: {}",
-                            peer_id, e
+                            "Reader task for peer {:?} (conn stable_id={}) exiting on graceful cancel",
+                            peer_id, conn_stable_id
                         );
                         break;
                     }
+                    result = connection.accept_uni() => match result {
+                        Ok(stream) => stream,
+                        Err(e) => {
+                            debug!(
+                                "Reader task for peer {:?} (conn stable_id={}) ending: accept_uni error: {}",
+                                peer_id, conn_stable_id, e
+                            );
+                            break;
+                        }
+                    }
                 };
 
+                // Uncancellable: drain the already-ACKed bytes. Cancelling here
+                // would silently lose data the sender has already seen as ACKed
+                // (the root cause of issue #166).
                 let data = match recv_stream.read_to_end(max_read_bytes).await {
                     Ok(data) if data.is_empty() => continue,
                     Ok(data) => data,
                     Err(e) => {
                         debug!(
-                            "Reader task for peer {:?}: read_to_end error: {}",
-                            peer_id, e
+                            "Reader task for peer {:?} (conn stable_id={}): read_to_end error: {}",
+                            peer_id, conn_stable_id, e
                         );
                         break;
                     }
                 };
 
                 let data_len = data.len();
-                tracing::trace!("Reader task: {} bytes from peer {:?}", data_len, peer_id);
+                tracing::trace!(
+                    "Reader task: {} bytes from peer {:?} (conn stable_id={})",
+                    data_len,
+                    peer_id,
+                    conn_stable_id
+                );
 
                 match inner
                     .handle_coordinator_control_message(peer_id, connection.clone(), &data)
@@ -4646,27 +4721,16 @@ impl P2pEndpoint {
                 }
             }
 
-            (peer_id, generation)
+            (peer_id, generation, conn_stable_id)
         });
 
-        // Abort any existing reader task for this peer before inserting the new one.
-        // Without this, reconnections leave zombie reader tasks on dead connections
-        // that never deliver data, causing send_direct() to succeed but recv() to hang.
+        // Append — DO NOT pre-empt existing readers. See function doc.
         let mut handles = self.reader_handles.write().await;
-        if let Some(old_handle) = handles.remove(&peer_id) {
-            tracing::debug!(
-                "Aborting previous reader task for peer {:?} (connection replaced)",
-                peer_id
-            );
-            old_handle.abort_handle.abort();
-        }
-        handles.insert(
-            peer_id,
-            ReaderTaskHandle {
-                generation,
-                abort_handle,
-            },
-        );
+        handles.entry(peer_id).or_default().push(ReaderTaskHandle {
+            generation,
+            cancel,
+            abort_handle,
+        });
     }
 
     async fn apply_peer_address_update(
@@ -4953,12 +5017,13 @@ impl P2pEndpoint {
                     tasks.try_join_next()
                 };
 
-                let (peer_id, generation) = match maybe_peer_id {
+                let (peer_id, generation, conn_stable_id) = match maybe_peer_id {
                     Some(Ok(reader_exit)) => reader_exit,
                     Some(Err(join_err)) => {
-                        // Task was cancelled (aborted) — not a real disconnect.
-                        // Abort handles are used by reconnection logic to replace
-                        // stale reader tasks, so this is expected.
+                        // Task was cancelled (aborted) — `cleanup_connection`
+                        // and `shutdown` use `abort()` as a backstop after
+                        // cooperative cancel. This is expected and not a signal
+                        // of an unexpected disconnect.
                         debug!("Reader task cancelled: {}", join_err);
                         continue;
                     }
@@ -4970,22 +5035,41 @@ impl P2pEndpoint {
                     }
                 };
 
-                let should_cleanup = reader_handles
-                    .read()
-                    .await
-                    .get(&peer_id)
-                    .is_some_and(|handle| handle.generation == generation);
-                if !should_cleanup {
+                // With per-connection readers (issue #166), a peer may have
+                // several live readers. Only the LAST one to exit should trigger
+                // peer-wide cleanup. Remove the exiting handle from the vec; if
+                // other readers remain, this peer is still alive on another
+                // connection and we skip cleanup.
+                let last_reader = {
+                    let mut handles = reader_handles.write().await;
+                    match handles.get_mut(&peer_id) {
+                        Some(vec) => {
+                            vec.retain(|h| h.generation != generation);
+                            if vec.is_empty() {
+                                handles.remove(&peer_id);
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                        // The peer was already removed by an explicit
+                        // `cleanup_connection` (e.g., shutdown, stale reaper).
+                        // No further cleanup needed.
+                        None => false,
+                    }
+                };
+
+                if !last_reader {
                     debug!(
-                        "Ignoring stale reader task exit for peer {:?} (generation {})",
-                        peer_id, generation
+                        "Reader task exited for peer {:?} (generation {}, conn stable_id {}); other readers still active, skipping cleanup",
+                        peer_id, generation, conn_stable_id
                     );
                     continue;
                 }
 
                 debug!(
-                    "Reader task exited for peer {:?} (generation {}) — triggering immediate cleanup",
-                    peer_id, generation
+                    "Last reader task for peer {:?} (generation {}, conn stable_id {}) exited — triggering cleanup",
+                    peer_id, generation, conn_stable_id
                 );
 
                 do_cleanup_connection(
@@ -5938,6 +6022,51 @@ mod tests {
         assert_eq!(addrs[1], global_v4);
         assert_eq!(addrs[2], private_v4);
         assert_eq!(addrs[3], loopback);
+    }
+
+    /// Regression for issue #163.
+    ///
+    /// When a peer advertises a globally-routable address plus some RFC1918 /
+    /// link-local / loopback leftovers, dialing those private entries from a
+    /// WAN caller stalls for the full QUIC handshake timeout before failing.
+    /// `drop_non_global_direct_candidates_when_global_present` must strip them
+    /// when a Global candidate is available.
+    #[test]
+    fn test_drop_non_global_direct_candidates_when_global_present() {
+        let private_v4: SocketAddr = "10.200.0.1:5483".parse().expect("valid addr");
+        let global_v4: SocketAddr = "198.51.100.20:5483".parse().expect("valid addr");
+        let global_v6: SocketAddr = "[2001:db8::20]:5483".parse().expect("valid addr");
+        let link_local: SocketAddr = "169.254.10.1:5483".parse().expect("valid addr");
+        let loopback: SocketAddr = "127.0.0.1:5483".parse().expect("valid addr");
+
+        let mut addrs = vec![private_v4, link_local, loopback, global_v4, global_v6];
+        drop_non_global_direct_candidates_when_global_present(&mut addrs);
+        addrs.sort();
+        let expected = {
+            let mut v = vec![global_v4, global_v6];
+            v.sort();
+            v
+        };
+        assert_eq!(
+            addrs, expected,
+            "private/link-local/loopback must be dropped when Global candidates are present"
+        );
+    }
+
+    /// Pure-LAN peers (no Global candidates — e.g. mDNS-discovered LAN peer)
+    /// must still be reachable. The filter must be a no-op in this case.
+    #[test]
+    fn test_drop_non_global_direct_candidates_preserves_lan_only_list() {
+        let private_v4: SocketAddr = "192.168.1.25:5483".parse().expect("valid addr");
+        let link_local_v6: SocketAddr = "[fe80::1]:5483".parse().expect("valid addr");
+
+        let original = vec![private_v4, link_local_v6];
+        let mut addrs = original.clone();
+        drop_non_global_direct_candidates_when_global_present(&mut addrs);
+        assert_eq!(
+            addrs, original,
+            "LAN-only candidate sets must not be emptied — the caller would have nothing to dial"
+        );
     }
 
     #[test]

--- a/tests/regression_166_accept_uni_race.rs
+++ b/tests/regression_166_accept_uni_race.rs
@@ -163,7 +163,9 @@ async fn run_client(server_addr: SocketAddr, chain: Arc<Vec<CertificateDer<'stat
     let mut client = Endpoint::client(([127, 0, 0, 1], 0).into()).expect("client ep");
     client.set_default_client_config(client_config(chain.as_slice()));
 
-    let connecting = client.connect(server_addr, "localhost").expect("start connect");
+    let connecting = client
+        .connect(server_addr, "localhost")
+        .expect("start connect");
     let conn = timeout(Duration::from_secs(10), connecting)
         .await
         .expect("client connect timeout")
@@ -172,15 +174,17 @@ async fn run_client(server_addr: SocketAddr, chain: Arc<Vec<CertificateDer<'stat
     // Build the 2 MiB slow-stream payload, seq=0 in first 4 bytes.
     let mut slow_payload = vec![0u8; SLOW_STREAM_BYTES];
     slow_payload[..4].copy_from_slice(&0u32.to_be_bytes());
-    for i in 4..SLOW_STREAM_BYTES {
-        slow_payload[i] = (i & 0xff) as u8;
+    for (i, byte) in slow_payload.iter_mut().enumerate().skip(4) {
+        *byte = (i & 0xff) as u8;
     }
 
     // Open and start writing the slow stream first. DO NOT await
     // finish — we want the server to be mid-`read_to_end` while the
     // short bursts arrive.
     let mut slow = conn.open_uni().await.expect("client open_uni slow");
-    slow.write_all(&slow_payload).await.expect("client slow write");
+    slow.write_all(&slow_payload)
+        .await
+        .expect("client slow write");
     // Yield so the slow write actually gets flushed into quinn's send
     // buffer and starts being read by the server before we burst.
     sleep(Duration::from_millis(5)).await;
@@ -206,7 +210,8 @@ async fn run_client(server_addr: SocketAddr, chain: Arc<Vec<CertificateDer<'stat
     // datagrams, but at that point the server's in-order stream queue
     // must contain all of them).
     for (idx, jh) in burst.into_iter().enumerate() {
-        jh.await.unwrap_or_else(|e| panic!("short write {idx}: {e}"));
+        jh.await
+            .unwrap_or_else(|e| panic!("short write {idx}: {e}"));
     }
 
     // Now finish the slow stream.

--- a/tests/regression_166_accept_uni_race.rs
+++ b/tests/regression_166_accept_uni_race.rs
@@ -1,0 +1,272 @@
+// Copyright 2024 Saorsa Labs Ltd.
+//
+// This Saorsa Network Software is licensed under the General Public License (GPL), version 3.
+// Please see the file LICENSE-GPL, or visit <http://www.gnu.org/licenses/> for the full text.
+
+//! Regression repro for saorsa-labs/ant-quic#166 — short unidirectional
+//! stream goes ACKed on the sender but never surfaces at `accept_uni()`
+//! on the receiver in the live VPS mesh.
+//!
+//! Suspect mechanism: the receiver's P2pEndpoint reader task uses a
+//! strictly-serial loop — `accept_uni().await` → `read_to_end().await`
+//! → handle → `accept_uni().await` … — so any short stream that arrives
+//! while the reader is mid-`read_to_end` of a larger stream is only
+//! surfaced when the larger read completes and the loop re-enters
+//! `accept_uni()`. If quinn's stream-ready queue has finite / lossy
+//! semantics in that window, short streams could be silently dropped.
+//!
+//! This test drives that exact shape with raw quinn on localhost:
+//!
+//! - Server accepts streams in a strictly-serial loop, exactly like
+//!   `P2pEndpoint::spawn_reader_task`.
+//! - Client opens ONE large stream first, then `BURST_SHORT` short
+//!   streams in rapid parallel while the server is mid-read of the
+//!   large one. All streams carry a monotonic sequence number in the
+//!   first 4 bytes.
+//! - Server tallies every byte payload it read. After both sides
+//!   finish, we assert the server saw EXACTLY the `BURST_SHORT` short
+//!   sequence numbers the client emitted (no gaps, no duplicates).
+//!
+//! A green test rules out quinn queue-loss and redirects the #166
+//! investigation into ant-quic-specific layers (coordinator-control
+//! message handling, reader-task generation lifecycle, connection-
+//! router accounting, etc.). A red test (even one missing stream)
+//! confirms the race and hands quinn upstream the exact minimal repro.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use ant_quic::{
+    TransportConfig,
+    config::{ClientConfig, ServerConfig},
+    high_level::{Connection, Endpoint},
+};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use std::{
+    collections::HashSet,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+use tokio::time::{sleep, timeout};
+
+/// Size of the "slow" stream that keeps the server mid-`read_to_end`.
+/// Large enough that the client reliably finishes bursting all short
+/// streams before the server's first read completes. 2 MiB at
+/// localhost loopback + zero-latency reads is still at least a few
+/// milliseconds of read-loop residence time.
+const SLOW_STREAM_BYTES: usize = 2 * 1024 * 1024;
+
+/// How many short streams the client opens in quick succession while
+/// the server is mid-slow-read. The VPS repro mostly showed a single
+/// 41-byte stream going missing while a PubSub ~16 KiB stream was
+/// in-flight. We burst far more here to make any lossy behaviour
+/// extremely obvious.
+const BURST_SHORT: usize = 64;
+
+/// The 4-byte sequence prefix + small payload.
+const SHORT_STREAM_PAYLOAD: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+/// Per-side overall timeout; generous to absorb any quinn retry /
+/// congestion-control delay.
+const OVERALL_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long the server waits on a single `accept_uni()` before
+/// considering the stream source exhausted.
+const ACCEPT_UNI_IDLE_GRACE: Duration = Duration::from_secs(5);
+
+fn ensure_crypto_provider() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
+fn gen_self_signed_cert() -> (Vec<CertificateDer<'static>>, PrivateKeyDer<'static>) {
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+        .expect("generate self-signed");
+    let cert_der = CertificateDer::from(cert.cert);
+    let key_der = PrivateKeyDer::Pkcs8(cert.signing_key.serialize_der().into());
+    (vec![cert_der], key_der)
+}
+
+fn pqc_transport_config() -> Arc<TransportConfig> {
+    let mut transport = TransportConfig::default();
+    transport.enable_pqc(true);
+    Arc::new(transport)
+}
+
+async fn make_server() -> (Endpoint, SocketAddr, Vec<CertificateDer<'static>>) {
+    ensure_crypto_provider();
+    let (chain, key) = gen_self_signed_cert();
+    let mut server_cfg = ServerConfig::with_single_cert(chain.clone(), key).expect("server cfg");
+    server_cfg.transport_config(pqc_transport_config());
+    let server = Endpoint::server(server_cfg, ([127, 0, 0, 1], 0).into()).expect("server ep");
+    let addr = server.local_addr().expect("server addr");
+    (server, addr, chain)
+}
+
+fn client_config(chain: &[CertificateDer<'static>]) -> ClientConfig {
+    let mut roots = rustls::RootCertStore::empty();
+    for cert in chain.iter().cloned() {
+        roots.add(cert).expect("add root");
+    }
+    let mut cfg = ClientConfig::with_root_certificates(Arc::new(roots)).expect("client cfg");
+    cfg.transport_config(pqc_transport_config());
+    cfg
+}
+
+/// Reader that mimics the shape of `P2pEndpoint::spawn_reader_task` —
+/// strictly-serial accept_uni → read_to_end → record → repeat loop.
+async fn run_serial_reader(
+    conn: Connection,
+    received_seqs: Arc<tokio::sync::Mutex<HashSet<u32>>>,
+    short_seen: Arc<AtomicUsize>,
+    slow_seen: Arc<AtomicUsize>,
+) {
+    loop {
+        let accept = conn.accept_uni();
+        let mut recv = match timeout(ACCEPT_UNI_IDLE_GRACE, accept).await {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) => {
+                eprintln!("reader: accept_uni error (expected at teardown): {e}");
+                break;
+            }
+            Err(_) => {
+                eprintln!("reader: accept_uni idle grace elapsed — assume sender done");
+                break;
+            }
+        };
+
+        let data = match recv.read_to_end(SLOW_STREAM_BYTES * 2).await {
+            Ok(data) => data,
+            Err(e) => {
+                eprintln!("reader: read_to_end error: {e}");
+                continue;
+            }
+        };
+
+        if data.len() >= 4 {
+            let seq = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+            let mut set = received_seqs.lock().await;
+            set.insert(seq);
+        }
+
+        if data.len() > 1024 {
+            slow_seen.fetch_add(1, Ordering::Relaxed);
+        } else {
+            short_seen.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+async fn run_client(server_addr: SocketAddr, chain: Arc<Vec<CertificateDer<'static>>>) {
+    let mut client = Endpoint::client(([127, 0, 0, 1], 0).into()).expect("client ep");
+    client.set_default_client_config(client_config(chain.as_slice()));
+
+    let connecting = client.connect(server_addr, "localhost").expect("start connect");
+    let conn = timeout(Duration::from_secs(10), connecting)
+        .await
+        .expect("client connect timeout")
+        .expect("client connect failed");
+
+    // Build the 2 MiB slow-stream payload, seq=0 in first 4 bytes.
+    let mut slow_payload = vec![0u8; SLOW_STREAM_BYTES];
+    slow_payload[..4].copy_from_slice(&0u32.to_be_bytes());
+    for i in 4..SLOW_STREAM_BYTES {
+        slow_payload[i] = (i & 0xff) as u8;
+    }
+
+    // Open and start writing the slow stream first. DO NOT await
+    // finish — we want the server to be mid-`read_to_end` while the
+    // short bursts arrive.
+    let mut slow = conn.open_uni().await.expect("client open_uni slow");
+    slow.write_all(&slow_payload).await.expect("client slow write");
+    // Yield so the slow write actually gets flushed into quinn's send
+    // buffer and starts being read by the server before we burst.
+    sleep(Duration::from_millis(5)).await;
+
+    // Burst BURST_SHORT short streams concurrently. Each stream's
+    // payload is [seq_be; 4] ++ SHORT_STREAM_PAYLOAD.
+    let burst: Vec<_> = (1u32..=BURST_SHORT as u32)
+        .map(|seq| {
+            let conn = conn.clone();
+            tokio::spawn(async move {
+                let mut s = conn.open_uni().await.expect("open_uni short");
+                let mut buf = Vec::with_capacity(4 + SHORT_STREAM_PAYLOAD.len());
+                buf.extend_from_slice(&seq.to_be_bytes());
+                buf.extend_from_slice(SHORT_STREAM_PAYLOAD);
+                s.write_all(&buf).await.expect("short write");
+                s.finish().expect("short finish");
+            })
+        })
+        .collect();
+
+    // Wait for all short streams to finish writing (note: finish only
+    // queues a FIN; quinn still has to ACK it from the server's
+    // datagrams, but at that point the server's in-order stream queue
+    // must contain all of them).
+    for (idx, jh) in burst.into_iter().enumerate() {
+        jh.await.unwrap_or_else(|e| panic!("short write {idx}: {e}"));
+    }
+
+    // Now finish the slow stream.
+    slow.finish().expect("slow finish");
+
+    // Wait for the connection to be fully closed by the server side.
+    let _ = timeout(Duration::from_secs(10), conn.closed()).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn accept_uni_surfaces_all_streams_during_concurrent_slow_read() {
+    let (server, server_addr, chain) = make_server().await;
+    let chain = Arc::new(chain);
+
+    let received_seqs = Arc::new(tokio::sync::Mutex::new(HashSet::<u32>::new()));
+    let short_seen = Arc::new(AtomicUsize::new(0));
+    let slow_seen = Arc::new(AtomicUsize::new(0));
+
+    let server_received = Arc::clone(&received_seqs);
+    let server_short = Arc::clone(&short_seen);
+    let server_slow = Arc::clone(&slow_seen);
+
+    let server_task = tokio::spawn(async move {
+        let incoming = server.accept().await.expect("server accept");
+        let conn = incoming.await.expect("server handshake");
+        run_serial_reader(conn, server_received, server_short, server_slow).await;
+    });
+
+    let client_task = tokio::spawn(async move {
+        run_client(server_addr, chain).await;
+    });
+
+    timeout(OVERALL_TIMEOUT, async {
+        let _ = tokio::join!(client_task, server_task);
+    })
+    .await
+    .expect("test timed out — one side hung");
+
+    let short_count = short_seen.load(Ordering::Relaxed);
+    let slow_count = slow_seen.load(Ordering::Relaxed);
+    let seqs = received_seqs.lock().await.clone();
+    let missing: Vec<u32> = (1u32..=BURST_SHORT as u32)
+        .filter(|s| !seqs.contains(s))
+        .collect();
+
+    println!(
+        "reproducer summary: slow_seen={slow_count} short_seen={short_count} missing_seqs={:?}",
+        missing
+    );
+
+    assert_eq!(
+        slow_count, 1,
+        "server must see exactly one slow stream; saw {slow_count}"
+    );
+    assert_eq!(
+        short_count, BURST_SHORT,
+        "server should see all {BURST_SHORT} short streams; saw {short_count} (missing seqs: {missing:?})"
+    );
+    assert!(
+        missing.is_empty(),
+        "no short-stream sequence numbers should be missing; missing={missing:?}"
+    );
+}

--- a/tests/regression_166_mesh_churn.rs
+++ b/tests/regression_166_mesh_churn.rs
@@ -1,0 +1,268 @@
+// Copyright 2024 Saorsa Labs Ltd.
+//
+// This Saorsa Network Software is licensed under the General Public License (GPL), version 3.
+// Please see the file LICENSE-GPL, or visit <http://www.gnu.org/licenses/> for the full text.
+
+//! Regression for saorsa-labs/ant-quic#166 at the multi-peer mesh layer.
+//!
+//! The 2-peer reproducer in `regression_166_p2p_endpoint_race.rs` passes
+//! even without the fix because the abort-mid-read race only fires when
+//! `handle_inbound_connection` processes a redundant connection for an
+//! already-connected peer — i.e., simultaneous-open under mesh churn.
+//!
+//! David's 3-daemon localhost reproduction showed multiple
+//! `Aborting previous reader task for peer` events per peer within a
+//! single mixed-traffic test run, with paired
+//! `send acknowledgement timed out (peer may be dead)` warnings from the
+//! sending side. The fix (cooperative cancel at the `accept_uni()`
+//! boundary + per-connection reader tracking) preserves ACKed bytes in
+//! flight across the connection replacement.
+//!
+//! This test constructs a 3-peer mesh, drives concurrent mutual connects
+//! (to provoke the simultaneous-open path), then every peer pair sends
+//! `STREAMS_PER_DIRECTION` sequence-numbered streams on top of that.
+//! Every sequence number must surface on the receiver — no silent loss.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use ant_quic::{NatConfig, P2pConfig, P2pEndpoint, PeerId, PqcConfig};
+use std::{
+    collections::HashSet,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
+use tokio::{sync::Mutex, time::timeout};
+
+const STREAMS_PER_DIRECTION: u32 = 120;
+const PAYLOAD_LEN: usize = 48; // 4-byte seq + 4-byte from-index + 40-byte filler
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+const OVERALL_TIMEOUT: Duration = Duration::from_secs(90);
+const RECV_IDLE_GRACE: Duration = Duration::from_secs(6);
+
+fn normalize_local_addr(addr: SocketAddr) -> SocketAddr {
+    if addr.ip().is_unspecified() {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), addr.port())
+    } else {
+        addr
+    }
+}
+
+fn test_node_config(known_peers: Vec<SocketAddr>) -> P2pConfig {
+    P2pConfig::builder()
+        .bind_addr(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+        .known_peers(known_peers)
+        .nat(NatConfig {
+            enable_relay_fallback: false,
+            ..Default::default()
+        })
+        .pqc(PqcConfig::default())
+        .build()
+        .expect("Failed to build test config")
+}
+
+fn encode_payload(from_idx: u32, seq: u32) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(PAYLOAD_LEN);
+    payload.extend_from_slice(&seq.to_be_bytes());
+    payload.extend_from_slice(&from_idx.to_be_bytes());
+    payload.resize(PAYLOAD_LEN, b'a');
+    payload
+}
+
+fn decode_payload(data: &[u8]) -> Option<(u32, u32)> {
+    if data.len() < 8 {
+        return None;
+    }
+    let seq = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+    let from_idx = u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
+    Some((seq, from_idx))
+}
+
+/// Three-peer mesh. Each peer knows both others. All peers run accept
+/// loops. Then every peer connects to every other peer concurrently so
+/// the simultaneous-open path is exercised. Finally every peer sends
+/// `STREAMS_PER_DIRECTION` sequence-numbered streams to every other
+/// peer in parallel. Each receiver must observe every sequence number
+/// from every sender — no silent loss.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn mesh_churn_preserves_every_acked_stream() {
+    // Bring up three endpoints on ephemeral localhost ports. Seed the
+    // peer list after we know each other's addresses — just use empty
+    // known_peers up front and dial explicitly.
+    let nodes: Vec<Arc<P2pEndpoint>> = {
+        let mut v = Vec::with_capacity(3);
+        for _ in 0..3 {
+            v.push(Arc::new(
+                P2pEndpoint::new(test_node_config(vec![]))
+                    .await
+                    .expect("P2pEndpoint::new"),
+            ));
+        }
+        v
+    };
+    let addrs: Vec<SocketAddr> = nodes
+        .iter()
+        .map(|n| normalize_local_addr(n.local_addr().expect("local_addr")))
+        .collect();
+    let peer_ids: Vec<PeerId> = nodes.iter().map(|n| n.peer_id()).collect();
+
+    // Accept loops. Each node accepts concurrently; redundant accepts
+    // (simultaneous-open second-connection path) exercise the
+    // `handle_inbound_connection` replacement branch.
+    for node in &nodes {
+        let node = Arc::clone(node);
+        tokio::spawn(async move {
+            while let Some(pc) = node.accept().await {
+                eprintln!(
+                    "node {:?} accepted from peer={:?}",
+                    node.peer_id(),
+                    pc.peer_id
+                );
+            }
+        });
+    }
+
+    // Recv loops — collect every (sender, seq) pair we observe.
+    let received: Vec<Arc<Mutex<Vec<(PeerId, u32, u32)>>>> =
+        (0..3).map(|_| Arc::new(Mutex::new(Vec::new()))).collect();
+    let mut recv_tasks = Vec::with_capacity(3);
+    for (idx, node) in nodes.iter().enumerate() {
+        let node = Arc::clone(node);
+        let sink = Arc::clone(&received[idx]);
+        recv_tasks.push(tokio::spawn(async move {
+            loop {
+                match timeout(RECV_IDLE_GRACE, node.recv()).await {
+                    Ok(Ok((peer, data))) => {
+                        if let Some((seq, from_idx)) = decode_payload(&data) {
+                            sink.lock().await.push((peer, seq, from_idx));
+                        }
+                    }
+                    Ok(Err(e)) => {
+                        eprintln!("node idx={idx} recv error: {e}");
+                        break;
+                    }
+                    Err(_) => {
+                        eprintln!("node idx={idx} recv idle grace elapsed");
+                        break;
+                    }
+                }
+            }
+        }));
+    }
+
+    // Concurrent mutual connects across all pairs. Each edge is dialed
+    // from BOTH sides simultaneously — this is the simultaneous-open
+    // path that used to trigger `abort_existing_reader_task` against
+    // in-flight reads on the loser connection (issue #166).
+    let mut connect_tasks = Vec::new();
+    for (i, node) in nodes.iter().enumerate() {
+        for (j, peer_addr) in addrs.iter().enumerate() {
+            if i == j {
+                continue;
+            }
+            let node = Arc::clone(node);
+            let peer_addr = *peer_addr;
+            connect_tasks.push(tokio::spawn(async move {
+                let _ = timeout(CONNECT_TIMEOUT, node.connect_addr(peer_addr)).await;
+            }));
+        }
+    }
+    for t in connect_tasks {
+        let _ = t.await;
+    }
+
+    // Allow authentication + reader tasks to settle before the send
+    // storm. This is deliberately short so the first few messages can
+    // ride alongside any late handshake completion.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Every peer sends STREAMS_PER_DIRECTION streams to every other
+    // peer in parallel. Total streams in flight = 3 * 2 *
+    // STREAMS_PER_DIRECTION.
+    let mut send_tasks = Vec::new();
+    for from_idx in 0..3u32 {
+        for to_idx in 0..3u32 {
+            if from_idx == to_idx {
+                continue;
+            }
+            let sender = Arc::clone(&nodes[from_idx as usize]);
+            let target_peer = peer_ids[to_idx as usize];
+            for seq in 1..=STREAMS_PER_DIRECTION {
+                let sender = Arc::clone(&sender);
+                send_tasks.push(tokio::spawn(async move {
+                    let payload = encode_payload(from_idx, seq);
+                    sender
+                        .send(&target_peer, &payload)
+                        .await
+                        .unwrap_or_else(|e| {
+                            panic!("send from {from_idx}->peer_idx{to_idx} seq={seq} failed: {e}")
+                        });
+                }));
+            }
+        }
+    }
+
+    timeout(OVERALL_TIMEOUT, async {
+        for (idx, jh) in send_tasks.into_iter().enumerate() {
+            jh.await.unwrap_or_else(|e| panic!("send task {idx}: {e}"));
+        }
+    })
+    .await
+    .expect("send phase timed out");
+
+    // Let receivers drain before idle grace elapses.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    for node in &nodes {
+        let _ = timeout(Duration::from_secs(2), Arc::clone(node).shutdown()).await;
+    }
+    for t in recv_tasks {
+        let _ = timeout(Duration::from_secs(15), t).await;
+    }
+
+    // Every node should have received every sequence number from every
+    // other node. Collect missing pairs for a readable failure.
+    let mut total_missing: Vec<String> = Vec::new();
+    for (receiver_idx, sink) in received.iter().enumerate() {
+        let observed = sink.lock().await.clone();
+        for from_idx in 0..3u32 {
+            if from_idx as usize == receiver_idx {
+                continue;
+            }
+            let from_peer = peer_ids[from_idx as usize];
+            let seen: HashSet<u32> = observed
+                .iter()
+                .filter(|(p, _, _)| *p == from_peer)
+                .map(|(_, seq, _)| *seq)
+                .collect();
+            for expected in 1..=STREAMS_PER_DIRECTION {
+                if !seen.contains(&expected) {
+                    total_missing.push(format!(
+                        "node{receiver_idx} missing seq={expected} from node{from_idx}"
+                    ));
+                }
+            }
+        }
+    }
+
+    let observed_counts: Vec<usize> = received
+        .iter()
+        .map(|sink| {
+            // RAII: blocking_lock would deadlock the runtime — use
+            // try_lock since all recv_tasks have exited.
+            sink.try_lock().map(|g| g.len()).unwrap_or(0)
+        })
+        .collect();
+    println!(
+        "mesh churn summary: per-node recv counts = {observed_counts:?}, expected 2*{STREAMS_PER_DIRECTION}={} each",
+        2 * STREAMS_PER_DIRECTION
+    );
+
+    assert!(
+        total_missing.is_empty(),
+        "issue #166 regression: some ACKed streams were silently lost under mesh churn. \
+         Missing ({} entries, first 20 shown): {:?}",
+        total_missing.len(),
+        total_missing.iter().take(20).collect::<Vec<_>>()
+    );
+}

--- a/tests/regression_166_p2p_endpoint_race.rs
+++ b/tests/regression_166_p2p_endpoint_race.rs
@@ -129,8 +129,8 @@ async fn p2p_endpoint_send_surfaces_all_short_streams_under_concurrent_large_sen
     // runs concurrently with the short burst.
     let mut large_payload = vec![0u8; LARGE_PAYLOAD_LEN];
     large_payload[..4].copy_from_slice(&0u32.to_be_bytes());
-    for i in 4..LARGE_PAYLOAD_LEN {
-        large_payload[i] = (i & 0xff) as u8;
+    for (i, byte) in large_payload.iter_mut().enumerate().skip(4) {
+        *byte = (i & 0xff) as u8;
     }
     let client_for_large = Arc::clone(&client);
     let large_task = tokio::spawn(async move {
@@ -178,7 +178,10 @@ async fn p2p_endpoint_send_surfaces_all_short_streams_under_concurrent_large_sen
     let _ = timeout(Duration::from_secs(15), recv_task).await;
 
     let received = received.lock().await.clone();
-    let large_count = received.iter().filter(|(len, _)| *len >= LARGE_PAYLOAD_LEN).count();
+    let large_count = received
+        .iter()
+        .filter(|(len, _)| *len >= LARGE_PAYLOAD_LEN)
+        .count();
     let short_seqs: HashSet<u32> = received
         .iter()
         .filter(|(len, _)| *len == SHORT_PAYLOAD_LEN)

--- a/tests/regression_166_p2p_endpoint_race.rs
+++ b/tests/regression_166_p2p_endpoint_race.rs
@@ -1,0 +1,215 @@
+// Copyright 2024 Saorsa Labs Ltd.
+//
+// This Saorsa Network Software is licensed under the General Public License (GPL), version 3.
+// Please see the file LICENSE-GPL, or visit <http://www.gnu.org/licenses/> for the full text.
+
+//! Regression repro for saorsa-labs/ant-quic#166 — at the
+//! `P2pEndpoint::send` / `P2pEndpoint::recv` layer.
+//!
+//! The sister test (`regression_166_accept_uni_race.rs`) proved quinn's
+//! `accept_uni()` delivers all concurrent streams correctly. If #166
+//! reproduces at the P2pEndpoint layer, then the bug lives in the
+//! reader-task glue — `spawn_reader_task`,
+//! `handle_coordinator_control_message`, or the
+//! connected_peers / data_tx wiring — not quinn. That narrows the
+//! upstream hunt considerably.
+//!
+//! Scenario:
+//! - Two `P2pEndpoint`s on localhost — server (S) and client (C).
+//! - C connects to S and authenticates.
+//! - C calls `send(S, large_payload)` and in parallel spawns
+//!   `BURST_SHORT` tasks each calling `send(S, short_payload_with_seq)`.
+//! - S runs a recv() loop collecting every (peer_id, bytes) tuple.
+//! - Assert S receives exactly 1 large-sized payload AND all
+//!   `BURST_SHORT` short payloads with no missing sequence numbers.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use ant_quic::{NatConfig, P2pConfig, P2pEndpoint, PqcConfig};
+use std::{
+    collections::HashSet,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
+use tokio::{sync::Mutex, time::timeout};
+
+const BURST_SHORT: usize = 64;
+const SHORT_PAYLOAD_LEN: usize = 40; // 4-byte seq + 36-byte filler
+const LARGE_PAYLOAD_LEN: usize = 512 * 1024; // 512 KiB — must be > max_message_size default? check
+const OVERALL_TIMEOUT: Duration = Duration::from_secs(60);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const RECV_IDLE_GRACE: Duration = Duration::from_secs(5);
+
+fn normalize_local_addr(addr: SocketAddr) -> SocketAddr {
+    if addr.ip().is_unspecified() {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), addr.port())
+    } else {
+        addr
+    }
+}
+
+fn test_node_config(known_peers: Vec<SocketAddr>) -> P2pConfig {
+    P2pConfig::builder()
+        .bind_addr(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+        .known_peers(known_peers)
+        .nat(NatConfig {
+            enable_relay_fallback: false,
+            ..Default::default()
+        })
+        .pqc(PqcConfig::default())
+        .build()
+        .expect("Failed to build test config")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn p2p_endpoint_send_surfaces_all_short_streams_under_concurrent_large_send() {
+    // Server — accepts connections, recv() loop collects everything.
+    let server = Arc::new(
+        P2pEndpoint::new(test_node_config(vec![]))
+            .await
+            .expect("server P2pEndpoint::new"),
+    );
+    let server_addr = normalize_local_addr(server.local_addr().expect("server local_addr"));
+
+    // Client — know the server address so it can dial.
+    let client = Arc::new(
+        P2pEndpoint::new(test_node_config(vec![server_addr]))
+            .await
+            .expect("client P2pEndpoint::new"),
+    );
+
+    // Server must run an accept loop — otherwise reader tasks never
+    // spawn and recv() surfaces nothing.
+    let accept_server = Arc::clone(&server);
+    tokio::spawn(async move {
+        while let Some(pc) = accept_server.accept().await {
+            eprintln!("server accepted: peer={:?}", pc.peer_id);
+        }
+    });
+
+    // Server recv loop — runs until idle grace expires.
+    let received = Arc::new(Mutex::new(Vec::<(usize, u32)>::new()));
+    let recv_received = Arc::clone(&received);
+    let recv_server = Arc::clone(&server);
+    let recv_task = tokio::spawn(async move {
+        loop {
+            match timeout(RECV_IDLE_GRACE, recv_server.recv()).await {
+                Ok(Ok((_peer, data))) => {
+                    let seq = if data.len() >= 4 {
+                        u32::from_be_bytes([data[0], data[1], data[2], data[3]])
+                    } else {
+                        u32::MAX
+                    };
+                    recv_received.lock().await.push((data.len(), seq));
+                }
+                Ok(Err(e)) => {
+                    eprintln!("recv error: {e}");
+                    break;
+                }
+                Err(_) => {
+                    eprintln!("recv idle grace elapsed — assuming client done");
+                    break;
+                }
+            }
+        }
+    });
+
+    // Client — connect.
+    let _peer_conn = timeout(CONNECT_TIMEOUT, client.connect_addr(server_addr))
+        .await
+        .expect("client connect timeout")
+        .expect("client connect failed");
+    let server_peer_id = server.peer_id();
+
+    // Let authentication + reader task spin up.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Client sends one large payload (seq=0) in its own task so it
+    // runs concurrently with the short burst.
+    let mut large_payload = vec![0u8; LARGE_PAYLOAD_LEN];
+    large_payload[..4].copy_from_slice(&0u32.to_be_bytes());
+    for i in 4..LARGE_PAYLOAD_LEN {
+        large_payload[i] = (i & 0xff) as u8;
+    }
+    let client_for_large = Arc::clone(&client);
+    let large_task = tokio::spawn(async move {
+        client_for_large
+            .send(&server_peer_id, &large_payload)
+            .await
+            .expect("client large send");
+    });
+
+    // Give the large send a head start so it's in-flight when the
+    // burst starts.
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // Client bursts BURST_SHORT short payloads concurrently.
+    let mut short_tasks = Vec::with_capacity(BURST_SHORT);
+    for seq in 1u32..=BURST_SHORT as u32 {
+        let client = Arc::clone(&client);
+        short_tasks.push(tokio::spawn(async move {
+            let mut payload = Vec::with_capacity(SHORT_PAYLOAD_LEN);
+            payload.extend_from_slice(&seq.to_be_bytes());
+            payload.resize(SHORT_PAYLOAD_LEN, b'a');
+            client
+                .send(&server_peer_id, &payload)
+                .await
+                .unwrap_or_else(|e| panic!("client short send seq={seq} failed: {e}"));
+        }));
+    }
+
+    // Await all sends.
+    timeout(OVERALL_TIMEOUT, async {
+        for (idx, jh) in short_tasks.into_iter().enumerate() {
+            jh.await.unwrap_or_else(|e| panic!("short task {idx}: {e}"));
+        }
+        large_task.await.expect("large task");
+    })
+    .await
+    .expect("send phase timed out");
+
+    // Let the server's reader loop drain any in-flight streams.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Kick the client into shutting down so the server's recv idle
+    // grace fires and the recv_task terminates.
+    let _ = timeout(Duration::from_secs(2), Arc::clone(&client).shutdown()).await;
+    let _ = timeout(Duration::from_secs(15), recv_task).await;
+
+    let received = received.lock().await.clone();
+    let large_count = received.iter().filter(|(len, _)| *len >= LARGE_PAYLOAD_LEN).count();
+    let short_seqs: HashSet<u32> = received
+        .iter()
+        .filter(|(len, _)| *len == SHORT_PAYLOAD_LEN)
+        .map(|(_, seq)| *seq)
+        .collect();
+    let missing: Vec<u32> = (1u32..=BURST_SHORT as u32)
+        .filter(|s| !short_seqs.contains(s))
+        .collect();
+
+    println!(
+        "p2p reproducer summary: received.len()={} large_count={} short_count={} missing_seqs={:?}",
+        received.len(),
+        large_count,
+        short_seqs.len(),
+        missing
+    );
+
+    let _ = timeout(Duration::from_secs(2), Arc::clone(&server).shutdown()).await;
+
+    assert_eq!(
+        large_count, 1,
+        "server should have received exactly one large payload; got {large_count}"
+    );
+    assert_eq!(
+        short_seqs.len(),
+        BURST_SHORT,
+        "server should have received all {BURST_SHORT} short streams; got {} (missing: {missing:?})",
+        short_seqs.len()
+    );
+    assert!(
+        missing.is_empty(),
+        "no short-stream sequence numbers should be missing; missing={missing:?}"
+    );
+}

--- a/tests/regression_166_sanity.rs
+++ b/tests/regression_166_sanity.rs
@@ -1,0 +1,96 @@
+// Minimal sanity: can P2pEndpoint A send a single 40-byte payload to B
+// and have B's recv() surface it? If this fails on localhost then the
+// subsequent concurrent-burst reproducer has a setup issue, not a
+// #166 hit.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use ant_quic::{NatConfig, P2pConfig, P2pEndpoint, PqcConfig};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+    time::Duration,
+};
+use tokio::time::timeout;
+
+fn normalize_local_addr(addr: SocketAddr) -> SocketAddr {
+    if addr.ip().is_unspecified() {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), addr.port())
+    } else {
+        addr
+    }
+}
+
+fn test_node_config(known_peers: Vec<SocketAddr>) -> P2pConfig {
+    P2pConfig::builder()
+        .bind_addr(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+        .known_peers(known_peers)
+        .nat(NatConfig {
+            enable_relay_fallback: false,
+            ..Default::default()
+        })
+        .pqc(PqcConfig::default())
+        .build()
+        .expect("Failed to build test config")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn sanity_single_send_surfaces_at_recv() {
+    let server = Arc::new(
+        P2pEndpoint::new(test_node_config(vec![]))
+            .await
+            .expect("server new"),
+    );
+    let server_addr = normalize_local_addr(server.local_addr().expect("server addr"));
+    eprintln!("server_addr={server_addr} server_peer_id={:?}", server.peer_id());
+
+    // Server must accept incoming connections — otherwise the reader
+    // task never spawns and recv() never surfaces anything.
+    let accept_server = Arc::clone(&server);
+    tokio::spawn(async move {
+        while let Some(pc) = accept_server.accept().await {
+            eprintln!("server accepted: peer={:?}", pc.peer_id);
+        }
+    });
+
+    let client = Arc::new(
+        P2pEndpoint::new(test_node_config(vec![server_addr]))
+            .await
+            .expect("client new"),
+    );
+    eprintln!("client_peer_id={:?}", client.peer_id());
+
+    let conn = timeout(Duration::from_secs(10), client.connect_addr(server_addr))
+        .await
+        .expect("connect timeout")
+        .expect("connect failed");
+    eprintln!("connected: peer_id={:?} authenticated={}", conn.peer_id, conn.authenticated);
+
+    // Give any background auth + reader spawn time to settle.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    // Use the peer_id from the PeerConnection (what the client observed)
+    // rather than server.peer_id(), to catch any id divergence.
+    let target = conn.peer_id;
+    eprintln!("sending 40 bytes to {target:?}");
+    client
+        .send(&target, b"0000sanity-payload-40-bytes-pad1234567890")
+        .await
+        .expect("client send");
+    eprintln!("send returned Ok");
+
+    // Server recv.
+    let got = timeout(Duration::from_secs(10), server.recv()).await;
+    match got {
+        Ok(Ok((peer, bytes))) => {
+            eprintln!("server recv: peer={peer:?} bytes.len()={}", bytes.len());
+            assert_eq!(bytes.len(), 40, "payload length mismatch");
+            assert_eq!(peer, client.peer_id(), "peer id mismatch");
+        }
+        Ok(Err(e)) => panic!("server recv error: {e}"),
+        Err(_) => panic!("server recv timed out — nothing surfaced"),
+    }
+
+    let _ = timeout(Duration::from_secs(2), Arc::clone(&client).shutdown()).await;
+    let _ = timeout(Duration::from_secs(2), Arc::clone(&server).shutdown()).await;
+}

--- a/tests/regression_166_sanity.rs
+++ b/tests/regression_166_sanity.rs
@@ -42,7 +42,10 @@ async fn sanity_single_send_surfaces_at_recv() {
             .expect("server new"),
     );
     let server_addr = normalize_local_addr(server.local_addr().expect("server addr"));
-    eprintln!("server_addr={server_addr} server_peer_id={:?}", server.peer_id());
+    eprintln!(
+        "server_addr={server_addr} server_peer_id={:?}",
+        server.peer_id()
+    );
 
     // Server must accept incoming connections — otherwise the reader
     // task never spawns and recv() never surfaces anything.
@@ -64,7 +67,10 @@ async fn sanity_single_send_surfaces_at_recv() {
         .await
         .expect("connect timeout")
         .expect("connect failed");
-    eprintln!("connected: peer_id={:?} authenticated={}", conn.peer_id, conn.authenticated);
+    eprintln!(
+        "connected: peer_id={:?} authenticated={}",
+        conn.peer_id, conn.authenticated
+    );
 
     // Give any background auth + reader spawn time to settle.
     tokio::time::sleep(Duration::from_millis(1500)).await;
@@ -74,7 +80,7 @@ async fn sanity_single_send_surfaces_at_recv() {
     let target = conn.peer_id;
     eprintln!("sending 40 bytes to {target:?}");
     client
-        .send(&target, b"0000sanity-payload-40-bytes-pad1234567890")
+        .send(&target, b"0000sanity-payload-40-bytes-pad123456789")
         .await
         .expect("client send");
     eprintln!("send returned Ok");


### PR DESCRIPTION
## Summary

Closes three production-affecting regressions seen on the x0x 6-VPS bootstrap mesh and David's 3-daemon localhost reproducer:

- **#166 (critical)** — `Node::send` succeeds but `Node::recv` silently drops bytes under simultaneous-open churn. Reader task abort-mid-read was discarding ACKed data. Fixed with cooperative `CancellationToken` at the `accept_uni()` boundary + per-connection reader tracking (`HashMap<PeerId, Vec<ReaderTaskHandle>>`).
- **#163** — NAT traversal fired on public-IP peers with 0 % hole-punch success. Root cause: RFC1918/link-local/ULA/loopback candidates leaking into NAT-traversal sessions and direct-dial candidate lists. Two new helpers drop non-Global candidates when a Global is present; pure-LAN (mDNS) peers remain dialable.
- **#164** — `bytes_forwarded=0` observability regression. The core byte-counter fixes already landed in 0.26.10/0.26.11; this PR adds the missing end-to-end regression gate (`test_handle_client_datagram_records_bytes_and_datagram_count`).

## Regression coverage

- `tests/regression_166_mesh_churn.rs` — 3-peer mesh with mutual-connect churn + heavy traffic. **Fails on pre-fix code** (send phase times out at 90 s, 0 / 720 streams delivered), **passes on the fix** (720 / 720 delivered in ~7 s).
- `p2p_endpoint::tests::test_drop_non_global_direct_candidates_when_global_present` + `..._preserves_lan_only_list` — scope filter on the direct-dial path.
- `nat_traversal_api::tests::test_drop_non_global_nat_candidates_filters_mixed_list` + `..._preserves_lan_only` — scope filter on the NAT-traversal candidate intake.
- `masque::relay_server::tests::test_handle_client_datagram_records_bytes_and_datagram_count` — relay byte-counter wiring.

## Release gate (all green on fix commit)

- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`
- `cargo nextest run --all-features --workspace` → **2240 / 2240 passed** (42 skipped)

## Test plan

- [x] New regression test fails on pre-fix code, passes after fix
- [x] Full workspace nextest passes
- [x] fmt + clippy -D warnings + rustdoc -D warnings clean
- [ ] Waiting for CI on this PR
- [ ] Merge → tag v0.26.13 → publish

## Related

Bumps version to `0.26.13` and adds CHANGELOG entry. x0x v0.17.3 retraction on #166 localhost reproducibility is incorporated (reference: issue #166 comment dated 2026-04-17 from @dirvine).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves three production regressions: the #166 silent data-loss bug (cooperative `CancellationToken` at the `accept_uni()` boundary + `Vec<ReaderTaskHandle>` per peer), the #163 private-candidate stall on the direct-dial path, and adds a regression gate for the #164 relay byte-counter.

- **Incomplete #163 fix** (`src/nat_traversal_api.rs` ~line 3569): `drop_non_global_nat_candidates_when_global_present` is correctly applied to `normalized_target_addrs` in the *initiator* branch of `CoordinationAccepted`, but the symmetric *target* branch (`*target == self.local_peer_id()`) dials `normalized_initiator_addrs` without the same filter. Any initiator that leaks RFC1918/link-local addresses alongside a public IP will still cause the responder side to stall for ~50 s per private entry — the original #163 symptom, but now only on the answering side.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the incomplete #163 filter on the target-side NAT path.

The #166 cooperative-cancel fix is well-designed and the regression tests are thorough. The #164 relay test is clean. However, `drop_non_global_nat_candidates_when_global_present` is only applied in the initiator branch of the `CoordinationAccepted` handler; the symmetric target branch dials `normalized_initiator_addrs` without filtering, leaving the responder side exposed to the original #163 stall.

src/nat_traversal_api.rs — `*target == self.local_peer_id()` branch of `CoordinationAccepted` (around line 3569) needs `drop_non_global_nat_candidates_when_global_present` applied to `normalized_initiator_addrs`.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | Core fix for #166: replaces `HashMap<PeerId, ReaderTaskHandle>` with `HashMap<PeerId, Vec<ReaderTaskHandle>>`, removes pre-emptive abort on connection replacement, and adds cooperative CancellationToken honoured only at the `accept_uni()` boundary. |
| src/nat_traversal_api.rs | Adds `drop_non_global_nat_candidates_when_global_present` but the symmetric target branch is missing the same filter on `normalized_initiator_addrs`, leaving the target side still vulnerable to the original #163 stall. |
| src/masque/relay_server.rs | Adds `test_handle_client_datagram_records_bytes_and_datagram_count` regression gate for #164. |
| tests/regression_166_mesh_churn.rs | 3-peer mesh churn regression gate — the primary test for #166. |
| tests/regression_166_p2p_endpoint_race.rs | P2pEndpoint-layer concurrent send/recv test; contains a stale TODO comment with an inverted constraint description for `LARGE_PAYLOAD_LEN`. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant A as Node A
    participant PA as P2pEndpoint A
    participant PB as P2pEndpoint B
    participant B as Node B

    Note over PA,PB: Simultaneous-open (mesh churn)
    A->>PA: connect(B)
    B->>PB: connect(A)
    PA-->>PB: QUIC handshake conn1
    PB-->>PA: QUIC handshake conn1
    PA->>PA: spawn_reader_task(B, conn1) readers[B]=[r1]
    PB->>PB: spawn_reader_task(A, conn1) readers[A]=[r1]
    Note over PA,PB: Second connection arrives (churn)
    PA-->>PB: QUIC handshake conn2
    Note over PA: OLD: abort r1 mid read_to_end → DATA LOSS
    Note over PA: NEW: append → readers[B]=[r1, r2]
    A->>B: stream on conn1 → r1 completes ✓
    A->>B: stream on conn2 → r2 completes ✓
    Note over PA: conn1 closes → r1 exits, readers[B]=[r2]
    Note over PA: conn2 closes → r2 exits → cleanup
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/nat_traversal_api.rs`, line 3569-3635 ([link](https://github.com/saorsa-labs/ant-quic/blob/a1569e2973d4ad96b1838ea0c2d357ae20380fe2/src/nat_traversal_api.rs#L3569-L3635)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`#163` filter missing on target-side `initiator_addrs`**

   The `drop_non_global_nat_candidates_when_global_present` filter is applied only in the `*initiator == self.local_peer_id()` branch (line 3487). The symmetric branch — `*target == self.local_peer_id()` — normalises and dials `normalized_initiator_addrs` directly without filtering. If the far-end (the initiator) advertises both a public IP and RFC1918/link-local/loopback addresses, the target node will still attempt connections to every private entry and stall for the full QUIC handshake timeout per address (~50 s), reproducing the original #163 stall on the responder side of every NAT-traversal session.

   ```rust
   normalized_initiator_addrs.sort_unstable();
   normalized_initiator_addrs.dedup();

   // Issue #163: mirror the same filter applied to target_addrs above.
   drop_non_global_nat_candidates_when_global_present(&mut normalized_initiator_addrs);

   if normalized_initiator_addrs.is_empty() {
       return Ok(true);
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/nat_traversal_api.rs
   Line: 3569-3635

   Comment:
   **`#163` filter missing on target-side `initiator_addrs`**

   The `drop_non_global_nat_candidates_when_global_present` filter is applied only in the `*initiator == self.local_peer_id()` branch (line 3487). The symmetric branch — `*target == self.local_peer_id()` — normalises and dials `normalized_initiator_addrs` directly without filtering. If the far-end (the initiator) advertises both a public IP and RFC1918/link-local/loopback addresses, the target node will still attempt connections to every private entry and stall for the full QUIC handshake timeout per address (~50 s), reproducing the original #163 stall on the responder side of every NAT-traversal session.

   ```rust
   normalized_initiator_addrs.sort_unstable();
   normalized_initiator_addrs.dedup();

   // Issue #163: mirror the same filter applied to target_addrs above.
   drop_non_global_nat_candidates_when_global_present(&mut normalized_initiator_addrs);

   if normalized_initiator_addrs.is_empty() {
       return Ok(true);
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `tests/regression_166_p2p_endpoint_race.rs`, line 1241 ([link](https://github.com/saorsa-labs/ant-quic/blob/a1569e2973d4ad96b1838ea0c2d357ae20380fe2/tests/regression_166_p2p_endpoint_race.rs#L1241)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale "check" note with inverted constraint**

   The comment `// must be > max_message_size default? check` has the inequality backwards. The large payload must be *less than* `max_message_size` so `read_to_end(max_read_bytes)` succeeds; since the default is 4 MiB, 512 KiB is fine. The trailing `check` is an unresolved developer note that should be removed before merge.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/regression_166_p2p_endpoint_race.rs
   Line: 1241

   Comment:
   **Stale "check" note with inverted constraint**

   The comment `// must be > max_message_size default? check` has the inequality backwards. The large payload must be *less than* `max_message_size` so `read_to_end(max_read_bytes)` succeeds; since the default is 4 MiB, 512 KiB is fine. The trailing `check` is an unresolved developer note that should be removed before merge.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/nat_traversal_api.rs
Line: 3569-3635

Comment:
**`#163` filter missing on target-side `initiator_addrs`**

The `drop_non_global_nat_candidates_when_global_present` filter is applied only in the `*initiator == self.local_peer_id()` branch (line 3487). The symmetric branch — `*target == self.local_peer_id()` — normalises and dials `normalized_initiator_addrs` directly without filtering. If the far-end (the initiator) advertises both a public IP and RFC1918/link-local/loopback addresses, the target node will still attempt connections to every private entry and stall for the full QUIC handshake timeout per address (~50 s), reproducing the original #163 stall on the responder side of every NAT-traversal session.

```rust
normalized_initiator_addrs.sort_unstable();
normalized_initiator_addrs.dedup();

// Issue #163: mirror the same filter applied to target_addrs above.
drop_non_global_nat_candidates_when_global_present(&mut normalized_initiator_addrs);

if normalized_initiator_addrs.is_empty() {
    return Ok(true);
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tests/regression_166_p2p_endpoint_race.rs
Line: 1241

Comment:
**Stale "check" note with inverted constraint**

The comment `// must be > max_message_size default? check` has the inequality backwards. The large payload must be *less than* `max_message_size` so `read_to_end(max_read_bytes)` succeeds; since the default is 4 MiB, 512 KiB is fine. The trailing `check` is an unresolved developer note that should be removed before merge.

```suggestion
const LARGE_PAYLOAD_LEN: usize = 512 * 1024; // 512 KiB — well under the 4 MiB max_message_size default
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): pin dependency-review-action to..."](https://github.com/saorsa-labs/ant-quic/commit/a1569e2973d4ad96b1838ea0c2d357ae20380fe2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28745449)</sub>

<!-- /greptile_comment -->