### PR TITLE
fix(stats): direct/relayed_connections are now live counts (closes #178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.6] - 2026-04-27
+
+### Fixed
+
+- **`direct_connections` and `relayed_connections` are now live counts, not
+  monotonic lifetime counters.** Issue #178: x0x's 5-daemon localhost proofs
+  reported `connected_peers=4` alongside `direct_connections=6` for the same
+  steady-state node. Root cause: `record_connection_established` incremented
+  `direct_connections` / `relayed_connections` on every new connection AND on
+  every traversal-method change, but `remove_connected_peer` only decremented
+  `active_connections` / `active_direct_incoming_connections` — it never
+  touched `direct_connections` or `relayed_connections`. A `Relay → Direct`
+  hole-punch upgrade also incremented `direct_connections` without
+  decrementing `relayed_connections`, so both ticked up on every transition.
+  Fixed by decrementing the previous method's live counter on transitions and
+  by decrementing the appropriate counter on disconnect; the steady-state
+  invariant `direct_connections + relayed_connections == active_connections
+  == connected_peers.len()` now holds. Affects observability only — the QUIC
+  transport itself was always tracking the right peers.
+
+## [0.27.5] - 2026-04-26
+
+### Fixed
+
+- **MASQUE relay session reaper now wired into production.** Idle relay
+  sessions previously accumulated unboundedly in long-lived nodes; the reaper
+  is now started alongside the rest of the relay machinery so stale sessions
+  are evicted on the configured cadence.
+
 ## [0.27.4] - 2026-04-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ant-quic"
-version = "0.27.5"
+version = "0.27.6"
 dependencies = [
  "ant-quic-workspace-hack",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "ant-quic"
-version = "0.27.5"
+version = "0.27.6"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -1412,6 +1412,21 @@ async fn record_connection_established(
         }
 
         if previous.is_none_or(|prev| prev.traversal_method != peer_conn.traversal_method) {
+            // Decrement the previous traversal method's live counter when an
+            // established connection transitions methods (e.g. Relay → Direct
+            // after hole-punch upgrade). Without this, both counters tick up
+            // and the steady-state mesh shows direct + relayed > active peers.
+            if let Some(prev) = previous {
+                match prev.traversal_method {
+                    TraversalMethod::Direct => {
+                        s.direct_connections = s.direct_connections.saturating_sub(1);
+                    }
+                    TraversalMethod::Relay => {
+                        s.relayed_connections = s.relayed_connections.saturating_sub(1);
+                    }
+                    TraversalMethod::HolePunch | TraversalMethod::PortPrediction => {}
+                }
+            }
             match peer_conn.traversal_method {
                 TraversalMethod::Direct => {
                     s.direct_connections += 1;
@@ -1480,6 +1495,17 @@ async fn remove_connected_peer(
         {
             let mut s = stats.write().await;
             s.active_connections = s.active_connections.saturating_sub(1);
+            // Keep direct_connections / relayed_connections as live counts so
+            // they stay consistent with connected_peers across disconnects.
+            match peer_conn.traversal_method {
+                TraversalMethod::Direct => {
+                    s.direct_connections = s.direct_connections.saturating_sub(1);
+                }
+                TraversalMethod::Relay => {
+                    s.relayed_connections = s.relayed_connections.saturating_sub(1);
+                }
+                TraversalMethod::HolePunch | TraversalMethod::PortPrediction => {}
+            }
             if peer_conn.traversal_method.is_direct() && peer_conn.side.is_server() {
                 s.active_direct_incoming_connections =
                     s.active_direct_incoming_connections.saturating_sub(1);
@@ -7730,7 +7756,8 @@ mod tests {
         assert_eq!(stats.active_connections, 1);
         assert_eq!(stats.successful_connections, 1);
         assert_eq!(stats.direct_connections, 1);
-        assert_eq!(stats.relayed_connections, 1);
+        // Relay → Direct transition decrements the previous method's live counter.
+        assert_eq!(stats.relayed_connections, 0);
         assert_eq!(stats.active_direct_incoming_connections, 1);
         drop(stats);
 
@@ -7788,6 +7815,205 @@ mod tests {
             event_rx.try_recv(),
             Err(tokio::sync::broadcast::error::TryRecvError::Empty)
         ));
+    }
+
+    #[tokio::test]
+    async fn test_record_connection_established_direct_to_relay_decrements_direct() {
+        let stats = RwLock::new(EndpointStats {
+            active_connections: 1,
+            successful_connections: 1,
+            direct_connections: 1,
+            active_direct_incoming_connections: 1,
+            ..EndpointStats::default()
+        });
+        let (event_tx, _event_rx) = tokio::sync::broadcast::channel(4);
+        let previous = PeerConnection {
+            peer_id: PeerId([0x60; 32]),
+            remote_addr: TransportAddr::Udp("127.0.0.1:9601".parse().expect("valid addr")),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Server,
+            authenticated: true,
+            connected_at: Instant::now(),
+            last_activity: Instant::now(),
+        };
+        let replacement = PeerConnection {
+            peer_id: previous.peer_id,
+            remote_addr: TransportAddr::Udp("203.0.113.30:9601".parse().expect("valid addr")),
+            traversal_method: TraversalMethod::Relay,
+            side: Side::Client,
+            authenticated: true,
+            connected_at: Instant::now(),
+            last_activity: Instant::now(),
+        };
+
+        record_connection_established(&stats, &event_tx, &replacement, Some(&previous)).await;
+
+        let stats = stats.read().await;
+        assert_eq!(stats.active_connections, 1);
+        assert_eq!(stats.direct_connections, 0);
+        assert_eq!(stats.relayed_connections, 1);
+        // The previous direct-incoming connection has been replaced by a
+        // Relay client-side connection, so the incoming-direct counter drops.
+        assert_eq!(stats.active_direct_incoming_connections, 0);
+    }
+
+    #[tokio::test]
+    async fn test_remove_connected_peer_decrements_direct_connections() {
+        let connected_peers = RwLock::new(HashMap::new());
+        let stats = RwLock::new(EndpointStats::default());
+        let (event_tx, _event_rx) = tokio::sync::broadcast::channel(4);
+        let peer_id = PeerId([0x70; 32]);
+
+        let peer_conn = PeerConnection {
+            peer_id,
+            remote_addr: TransportAddr::Udp("127.0.0.1:9701".parse().expect("valid addr")),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Server,
+            authenticated: true,
+            connected_at: Instant::now(),
+            last_activity: Instant::now(),
+        };
+        connected_peers
+            .write()
+            .await
+            .insert(peer_id, peer_conn.clone());
+        record_connection_established(&stats, &event_tx, &peer_conn, None).await;
+
+        {
+            let s = stats.read().await;
+            assert_eq!(s.direct_connections, 1);
+            assert_eq!(s.active_connections, 1);
+            assert_eq!(s.active_direct_incoming_connections, 1);
+        }
+
+        let removed = remove_connected_peer(
+            &connected_peers,
+            &stats,
+            &event_tx,
+            &peer_id,
+            DisconnectReason::ConnectionLost,
+        )
+        .await;
+        assert!(removed);
+
+        let s = stats.read().await;
+        assert_eq!(s.direct_connections, 0);
+        assert_eq!(s.active_connections, 0);
+        assert_eq!(s.active_direct_incoming_connections, 0);
+    }
+
+    #[tokio::test]
+    async fn test_remove_connected_peer_decrements_relayed_connections() {
+        let connected_peers = RwLock::new(HashMap::new());
+        let stats = RwLock::new(EndpointStats::default());
+        let (event_tx, _event_rx) = tokio::sync::broadcast::channel(4);
+        let peer_id = PeerId([0x71; 32]);
+
+        let peer_conn = PeerConnection {
+            peer_id,
+            remote_addr: TransportAddr::Udp("203.0.113.40:9702".parse().expect("valid addr")),
+            traversal_method: TraversalMethod::Relay,
+            side: Side::Client,
+            authenticated: true,
+            connected_at: Instant::now(),
+            last_activity: Instant::now(),
+        };
+        connected_peers
+            .write()
+            .await
+            .insert(peer_id, peer_conn.clone());
+        record_connection_established(&stats, &event_tx, &peer_conn, None).await;
+
+        {
+            let s = stats.read().await;
+            assert_eq!(s.relayed_connections, 1);
+            assert_eq!(s.active_connections, 1);
+        }
+
+        let removed = remove_connected_peer(
+            &connected_peers,
+            &stats,
+            &event_tx,
+            &peer_id,
+            DisconnectReason::ConnectionLost,
+        )
+        .await;
+        assert!(removed);
+
+        let s = stats.read().await;
+        assert_eq!(s.relayed_connections, 0);
+        assert_eq!(s.active_connections, 0);
+    }
+
+    /// Issue #178: in a steady-state mesh, the live-count invariant
+    /// `direct_connections + relayed_connections == active_connections`
+    /// must hold across connect → method-transition → disconnect churn.
+    #[tokio::test]
+    async fn test_direct_plus_relayed_equals_active_connections_under_churn() {
+        let connected_peers = RwLock::new(HashMap::new());
+        let stats = RwLock::new(EndpointStats::default());
+        let (event_tx, _event_rx) = tokio::sync::broadcast::channel(64);
+
+        let mk_conn = |id: u8, method: TraversalMethod, side: Side| PeerConnection {
+            peer_id: PeerId([id; 32]),
+            remote_addr: TransportAddr::Udp(
+                format!("127.0.0.1:{}", 10_000 + id as u16)
+                    .parse()
+                    .expect("valid addr"),
+            ),
+            traversal_method: method,
+            side,
+            authenticated: true,
+            connected_at: Instant::now(),
+            last_activity: Instant::now(),
+        };
+
+        // Establish 4 Direct peers (server-side incoming, like a mesh node).
+        for id in 1..=4u8 {
+            let conn = mk_conn(id, TraversalMethod::Direct, Side::Server);
+            connected_peers
+                .write()
+                .await
+                .insert(conn.peer_id, conn.clone());
+            record_connection_established(&stats, &event_tx, &conn, None).await;
+        }
+
+        // Transition peer 2 from Direct → Relay (e.g. NAT-traversal regression).
+        let prev2 = connected_peers
+            .read()
+            .await
+            .get(&PeerId([2; 32]))
+            .cloned()
+            .expect("peer 2 present");
+        let relayed2 = mk_conn(2, TraversalMethod::Relay, Side::Client);
+        connected_peers
+            .write()
+            .await
+            .insert(relayed2.peer_id, relayed2.clone());
+        record_connection_established(&stats, &event_tx, &relayed2, Some(&prev2)).await;
+
+        // Disconnect peer 4.
+        let removed = remove_connected_peer(
+            &connected_peers,
+            &stats,
+            &event_tx,
+            &PeerId([4; 32]),
+            DisconnectReason::ConnectionLost,
+        )
+        .await;
+        assert!(removed);
+
+        // Invariants: live counts agree with the connected_peers map.
+        let s = stats.read().await;
+        let peers_len = connected_peers.read().await.len();
+        assert_eq!(peers_len, 3, "3 peers remain after disconnecting peer 4");
+        assert_eq!(s.active_connections, peers_len);
+        assert_eq!(s.direct_connections, 2, "peers 1 and 3 are Direct");
+        assert_eq!(s.relayed_connections, 1, "peer 2 is Relay");
+        assert_eq!(
+            (s.direct_connections + s.relayed_connections) as usize,
+            peers_len
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Fixes #178: `direct_connections > connected_peers` in 5-node localhost mesh
- Makes `direct_connections` and `relayed_connections` live counts (matches field name + downstream expectations)
- Bumps version to **0.27.6**, `1641/1641` lib tests pass, clippy clean

## Root cause

x0x's 5-daemon localhost proofs reported `connected_peers=4` alongside `direct_connections=6` for the same steady-state node. The `EndpointStats` counters were maintained as **monotonic lifetime counters** even though their names and downstream consumers (`network/status` JSON, `Node::detect_nat_type`) treat them as live counts.

`record_connection_established` incremented `direct_connections` / `relayed_connections` on every new connection AND on every traversal-method change, but `remove_connected_peer` only decremented `active_connections` and `active_direct_incoming_connections` — it never touched direct/relayed. A `Relay → Direct` hole-punch upgrade also incremented `direct_connections` without decrementing `relayed_connections`, so both counters ticked up on every transition and never came back down.

## Fix

- Decrement the previous method's counter in `record_connection_established` when transitioning between Direct/Relay
- Decrement the appropriate counter in `remove_connected_peer` based on the removed peer's `traversal_method`

The steady-state invariant `direct_connections + relayed_connections == active_connections == connected_peers.len()` now holds.

## Test plan

- [x] Updated `test_record_connection_established_replacement_does_not_double_count` (assertion previously enshrined the bug — Relay→Direct should leave `relayed_connections` at 0, not 1)
- [x] Added `test_record_connection_established_direct_to_relay_decrements_direct`
- [x] Added `test_remove_connected_peer_decrements_direct_connections`
- [x] Added `test_remove_connected_peer_decrements_relayed_connections`
- [x] Added `test_direct_plus_relayed_equals_active_connections_under_churn` (issue-#178 invariant under connect → method-transition → disconnect churn)
- [x] `cargo test --lib` — 1641 passed, 0 failed
- [x] `cargo clippy --lib --tests -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

## Backwards compat

Affects **observability only** — the QUIC transport itself was always tracking the right peers, so downstream traffic is unaffected. Bumping patch (0.27.5 → 0.27.6) since the field name and downstream consumers always implied live-count semantics; this is a bugfix, not a breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug (#178) where `direct_connections` and `relayed_connections` in `EndpointStats` were monotonically increasing lifetime counters rather than live counts, causing `direct_connections > connected_peers` in steady-state meshes. The fix adds symmetric decrements in `record_connection_established` (when transitioning between traversal methods) and in `remove_connected_peer` (on disconnect), both using `saturating_sub` to guard against underflow. Five new unit tests cover Direct→Relay transitions, Relay→Direct transitions, and the composite churn invariant; they are thorough and correct.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the fix is narrowly scoped to observability counters and doesn't touch transport logic; all 1641 lib tests pass.

The core logic is correct and well-tested. The only finding is a P2 imprecision in the CHANGELOG invariant claim (HolePunch/PortPrediction connections still break the stated invariant), which is a pre-existing design gap not introduced by this PR.

No files require special attention; src/p2p_endpoint.rs is the only substantive change and it is correct.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | Core fix: adds symmetric decrements for `direct_connections` / `relayed_connections` on method transitions and disconnects; five new tests validate all transition/disconnect paths |
| CHANGELOG.md | Adds 0.27.6 and 0.27.5 entries describing the live-count fix and the relay session reaper wiring |
| Cargo.toml | Version bump from 0.27.5 → 0.27.6 consistent with the bugfix patch release |
| Cargo.lock | Lock file updated to reflect the 0.27.6 version bump; no new dependencies added |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant store_connected_peer
    participant record_connection_established
    participant EndpointStats
    participant remove_connected_peer

    Note over Caller,EndpointStats: New connection (previous = None)
    Caller->>store_connected_peer: peer_conn (Direct)
    store_connected_peer->>EndpointStats: insert peer_conn
    store_connected_peer->>record_connection_established: peer_conn, previous=None
    record_connection_established->>EndpointStats: active_connections += 1
    record_connection_established->>EndpointStats: direct_connections += 1

    Note over Caller,EndpointStats: Method transition (Relay → Direct hole-punch upgrade)
    Caller->>store_connected_peer: peer_conn (Direct), previous=Relay
    store_connected_peer->>EndpointStats: insert peer_conn (replaces old)
    store_connected_peer->>record_connection_established: peer_conn, previous=Some(Relay)
    record_connection_established->>EndpointStats: active_connections unchanged
    record_connection_established->>EndpointStats: relayed_connections -= 1  [NEW]
    record_connection_established->>EndpointStats: direct_connections += 1

    Note over Caller,EndpointStats: Disconnect
    Caller->>remove_connected_peer: peer_id
    remove_connected_peer->>EndpointStats: remove from connected_peers
    remove_connected_peer->>EndpointStats: active_connections -= 1
    remove_connected_peer->>EndpointStats: direct_connections -= 1  [NEW]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: CHANGELOG.md
Line: 27

Comment:
**Invariant claim is imprecise for `HolePunch`/`PortPrediction` connections**

The stated invariant `direct_connections + relayed_connections == active_connections` doesn't hold whenever a peer is stored with `TraversalMethod::HolePunch` or `TraversalMethod::PortPrediction`. Both variants hit the `=> {}` arm in every match block, so they contribute to `active_connections` but not to either named counter. The existing test `test_record_connection_established_updates_hole_punch_stats_once` already demonstrates this (`active_connections=1`, `direct_connections=0`, `relayed_connections=0`). The invariant holds for the Direct/Relay case fixed by this PR, but the changelog wording implies it holds universally.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(stats): direct/relayed\_connections a..."](https://github.com/saorsa-labs/ant-quic/commit/49ebcc3c969dbbbfcae562f07eb8a862ea3c63ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29811149)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->