### PR TITLE
fix(deps): bump rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,9 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- Bumps `rustls-webpki` from 0.103.12 → 0.103.13 via `cargo update -p rustls-webpki`.
- Closes the reachable-panic vulnerability in CRL parsing (`RUSTSEC-2026-0104`).
- Unblocks PR #179 — the same advisory is the root cause of four of its six CI failures (Policy Check, Security Audit, Vulnerability Scan, CI Gate). Once this lands on master, #179 just needs a rebase + re-run.

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --lib` — **1637 / 1637 pass** (incl. previously-flaky `node::tests::test_connect_peer_uses_upserted_peer_hints`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)