### PR TITLE
fix(ack): X0X-0060 raise duplicate-safe ACK retry cap 2s → 6s

### DIFF
--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -116,8 +116,14 @@ const ACK_RECEIVE_ADMISSION_TIMEOUT: Duration = Duration::from_millis(100);
 /// receiver budget exposes response-write starvation directly instead of
 /// burying it inside an opaque sender timeout.
 const ACK_RESPONSE_WRITE_TIMEOUT: Duration = Duration::from_millis(500);
-/// Retry budget for the duplicate-safe ACK-v2 retry after sender timeout.
-const ACK_TIMEOUT_RETRY_TIMEOUT: Duration = Duration::from_secs(2);
+/// Upper bound for the duplicate-safe ACK-v2 retry after sender timeout.
+///
+/// The retry reuses the original ACK-v2 request ID, so the receiver can replay
+/// an already-accepted outcome without delivering the payload twice. This needs
+/// to be large enough for WAN tails: a 2s retry cap caused repeated false
+/// negatives on long cross-region paths where the receiver admitted the
+/// payload but the sender had already timed out and reset the response stream.
+const ACK_TIMEOUT_RETRY_TIMEOUT: Duration = Duration::from_secs(6);
 /// ACK-v2 request/response stream priority.
 const ACK_STREAM_PRIORITY: i32 = 16;
 /// Probe request/response stream priority. Probes are diagnostic traffic and
@@ -6259,7 +6265,7 @@ impl P2pEndpoint {
         }
 
         self.record_ack_retry_outcome(*peer_id, AckOutcome::SenderRetryAttempted);
-        let retry_timeout = std::cmp::min(timeout_duration, ACK_TIMEOUT_RETRY_TIMEOUT);
+        let retry_timeout = Self::ack_timeout_retry_timeout(timeout_duration);
         if retry_timeout.is_zero() {
             self.record_ack_retry_outcome(*peer_id, AckOutcome::SenderRetryFailed);
             return first;
@@ -6278,6 +6284,10 @@ impl P2pEndpoint {
                 Err(error)
             }
         }
+    }
+
+    fn ack_timeout_retry_timeout(timeout_duration: Duration) -> Duration {
+        std::cmp::min(timeout_duration, ACK_TIMEOUT_RETRY_TIMEOUT)
     }
 
     fn record_ack_retry_outcome(&self, peer_id: PeerId, outcome: AckOutcome) {
@@ -8624,6 +8634,25 @@ mod tests {
     // ------------------------------------------------------------------
     // ACK request dedupe
     // ------------------------------------------------------------------
+
+    #[test]
+    fn ack_timeout_retry_budget_preserves_wan_class_caller_timeout() {
+        assert_eq!(
+            P2pEndpoint::ack_timeout_retry_timeout(Duration::from_secs(6)),
+            Duration::from_secs(6),
+            "X0X-0060: a 6s cross-region ACK budget must not be clipped to the old 2s retry cap"
+        );
+        assert_eq!(
+            P2pEndpoint::ack_timeout_retry_timeout(Duration::from_millis(750)),
+            Duration::from_millis(750),
+            "short diagnostic budgets remain caller-bounded"
+        );
+        assert_eq!(
+            P2pEndpoint::ack_timeout_retry_timeout(Duration::from_secs(30)),
+            ACK_TIMEOUT_RETRY_TIMEOUT,
+            "very large caller budgets are still capped for retry"
+        );
+    }
 
     #[test]
     fn ack_request_dedupe_replays_matching_request_id_once() {


### PR DESCRIPTION
## Summary

Fixes the X0X-0060 root cause: the duplicate-safe ACK-v2 retry budget was silently clipped to 2 s by `std::cmp::min(caller_budget, ACK_TIMEOUT_RETRY_TIMEOUT)` even when callers passed a WAN-class budget. On the longest cross-region paths in the SOTA-Borrow VPS mesh under sustained 4-hour load, this caused ACK-v2 false negatives — the receiver admitted the payload (X0X-0037 dedupe makes the replay safe) but the ACK response write completed *after* the sender had timed out and reset the response stream.

The 4 h broad-launch soak on the released stack (x0x 0.19.33 + saorsa-gossip 0.5.39 + ant-quic 0.27.14) ended **9/16 GO**, with all 6 ACK timeouts on the two longest paths (5× nuremberg→singapore @ ~170 ms one-way, 1× helsinki→sydney @ ~280 ms one-way). Proof: [x0x soak dir](https://github.com/saorsa-labs/x0x/tree/main/proofs/launch-readiness-soak-20260509T223637Z-4h-v0_19_33-phase-b-merged).

## Change

- `ACK_TIMEOUT_RETRY_TIMEOUT`: 2 s → **6 s**
- Extracted retry-budget calculation into `Self::ack_timeout_retry_timeout(timeout_duration)` so the contract is unit-testable
- New test `ack_timeout_retry_budget_preserves_wan_class_caller_timeout` covering three regimes:
  - 6 s caller passes through unclipped (the WAN-class case)
  - 750 ms diagnostic budget remains caller-bounded
  - 30 s caller still capped to 6 s

No wire-format change. No public API change. No behaviour change for short-budget callers.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test --all-features --workspace` — 2382 passed, 0 failed
- [x] New ACK retry test passes
- [x] `lifecycle_sender_stale` (yesterday's deflake) still 1/1 in isolation
- [ ] 4 h broad-launch soak on patched stack (requires release + redeploy; gated separately as ant-quic 0.27.15 + x0x 0.19.34 ship)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Raises the duplicate-safe ACK-v2 retry cap from 2 s to 6 s to stop WAN-class retry budgets from being silently clipped on long cross-region paths, and extracts the cap logic into a private helper so it can be unit-tested.

- `ACK_TIMEOUT_RETRY_TIMEOUT` bumped 2 s → 6 s; callers below the new cap still receive their caller-bounded budget unchanged.
- Inline `std::cmp::min` replaced with `Self::ack_timeout_retry_timeout(timeout_duration)`, a private pure function with no behaviour change at the call site.
- New test `ack_timeout_retry_budget_preserves_wan_class_caller_timeout` covers the pass-through (6 s), short-budget (750 ms), and over-cap (30 s) regimes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single constant change with evidence from production soak data, no wire-format impact, and a new focused unit test.

The change is small and contained to one constant and one extracted helper. Short-budget callers are unaffected, the dedupe safety of replaying the same request_id was already in place before this PR, and the three new assertions confirm all behavioural regimes. The soak evidence is concrete and the root-cause analysis is clear.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | ACK_TIMEOUT_RETRY_TIMEOUT raised from 2 s to 6 s, inline min() extracted into a private testable helper, and a new three-case unit test added; no logic change for short-budget callers |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant Sender as send_ack_v2<br/>(P2pEndpoint)
    participant Receiver

    Caller->>Sender: send_ack_v2(data, timeout_duration)
    Sender->>Sender: generate request_id (16 bytes)
    Sender->>Receiver: send_ack_exchange_once(request_id, timeout_duration)

    alt First attempt succeeds
        Receiver-->>Sender: ACK accepted
        Sender-->>Caller: Ok(())
    else First attempt AckTimeout
        Sender->>Sender: record SenderRetryAttempted
        Sender->>Sender: "retry_timeout = min(timeout_duration, ACK_TIMEOUT_RETRY_TIMEOUT=6s)"
        note over Sender: Before PR cap was 2s, WAN budgets silently clipped
        note over Sender: After PR cap is 6s, 6s WAN budget passes through
        alt "retry_timeout == zero"
            Sender->>Sender: record SenderRetryFailed
            Sender-->>Caller: Err(AckTimeout)
        else "retry_timeout > zero"
            Sender->>Receiver: send_ack_exchange_once(same request_id, retry_timeout)
            note over Receiver: Dedupe cache replays already-accepted outcome safely
            alt Retry succeeds
                Receiver-->>Sender: ACK replayed
                Sender->>Sender: record SenderRetryAccepted
                Sender-->>Caller: Ok(())
            else Retry fails
                Sender->>Sender: record SenderRetryFailed
                Sender-->>Caller: Err(...)
            end
        end
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(ack): X0X-0060 raise duplicate-safe ..."](https://github.com/saorsa-labs/ant-quic/commit/059acb6d52db1178f93f74187bcc70a692656a72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31481718)</sub>

<!-- /greptile_comment -->