### PR TITLE
fix: X0X-0062 reviewer P2 round 2 — authoritative cleanup at trigger_liveness_close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.18] - 2026-05-11
+
+X0X-0062 reviewer P2 (round 2) fix: lifecycle state now authoritative.
+
+### Fixed
+
+- **Reviewer P2 (round 2):** `trigger_liveness_close` previously emitted
+  `Closing/Closed{LivenessTimeout}` lifecycle events and called
+  `Connection::close()` directly. Quinn's local close became
+  `ConnectionError::LocallyClosed` in the inner state machine, and the
+  connection remained in `connected_peers` until a later reaper run — so
+  `is_connected(peer_id)` could still return true after the liveness close,
+  and `close_reason_from_connection` would downgrade the diagnostic from
+  `LivenessTimeout` to `LocallyClosed`. Lifecycle state was emitted but not
+  authoritative; the connection survived in a zombie form until the reaper
+  caught it.
+- Fix: trigger site now invokes the existing
+  `cleanup_connection(DisconnectReason::LivenessTimeout)` helper, which
+  threads `LivenessTimeout` through every layer:
+  1. emits `Closing { LivenessTimeout }`
+  2. calls `remove_connection_with_reason(LivenessTimeout)` on the inner
+     NAT-traversal endpoint — removing the connection from the state map
+     AND tagging the inner record
+  3. emits `Closed { LivenessTimeout }`
+  4. fails any in-flight ACK waiters with `LivenessTimeout` close reason
+  5. tears down reader handles + removes the peer from `connected_peers`
+- Added `DisconnectReason::LivenessTimeout` variant and wired it through
+  `close_reason_for_disconnect`, `link_transport_impl`, and `node_event`.
+- New unit test
+  `disconnect_reason_liveness_timeout_maps_to_close_reason_liveness_timeout`
+  pins the mapping that makes the cleanup path's `close_reason` actually
+  carry `LivenessTimeout` through to all observers.
+
+### Tested
+
+- `cargo test --all-features --workspace`: **2390 passed, 0 failed** (up
+  from 2389 in 0.27.17; one new test).
+- `cargo clippy --all-features --all-targets -- -D warnings` clean.
+
 ## [0.27.17] - 2026-05-11
 
 X0X-0062 reviewer-finding fixes for the 0.27.16 liveness-timeout shipment.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ant-quic"
-version = "0.27.17"
+version = "0.27.18"
 dependencies = [
  "ant-quic-workspace-hack",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "ant-quic"
-version = "0.27.17"
+version = "0.27.18"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/src/link_transport_impl.rs
+++ b/src/link_transport_impl.rs
@@ -537,6 +537,16 @@ impl P2pLinkTransport {
                                 crate::p2p_endpoint::DisconnectReason::ConnectionLost => {
                                     DisconnectReason::Reset
                                 }
+                                crate::p2p_endpoint::DisconnectReason::LivenessTimeout => {
+                                    // X0X-0062: from this transport's view a
+                                    // liveness-timeout looks the same as a
+                                    // transport timeout — the application
+                                    // concluded the path is dead. The
+                                    // distinction is preserved in lifecycle
+                                    // events; this surface is the simpler
+                                    // user-facing channel.
+                                    DisconnectReason::Timeout
+                                }
                             };
                             // Update capabilities cache
                             if let Ok(mut state) = state.write() {

--- a/src/node_event.rs
+++ b/src/node_event.rs
@@ -399,6 +399,12 @@ impl From<P2pDisconnectReason> for DisconnectReason {
             }
             P2pDisconnectReason::ConnectionLost => Self::Reset,
             P2pDisconnectReason::RemoteClosed => Self::ApplicationClose,
+            // X0X-0062: a liveness-timeout disconnect maps to Timeout from
+            // the user-facing event surface — same shape as a transport
+            // idle-timeout. The LivenessTimeout-specific close reason is
+            // preserved at the lifecycle-event layer for observers that need
+            // to distinguish the two.
+            P2pDisconnectReason::LivenessTimeout => Self::Timeout,
         }
     }
 }

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -1946,6 +1946,13 @@ pub enum DisconnectReason {
     ConnectionLost,
     /// Remote closed
     RemoteClosed,
+    /// X0X-0062: the application-layer liveness detector concluded the data
+    /// path is half-dead (5 consecutive ACK-v2 retry double-failures within
+    /// 60 s while QUIC keepalives still report the connection as `Live`).
+    /// Differs from `Timeout`: that's the QUIC transport idle-timer firing;
+    /// this is the application observing that nothing is getting through
+    /// despite QUIC saying everything is fine.
+    LivenessTimeout,
 }
 
 fn close_reason_from_connection(
@@ -2002,6 +2009,7 @@ fn close_reason_for_disconnect(reason: &DisconnectReason) -> ConnectionCloseReas
         DisconnectReason::AuthenticationFailed => ConnectionCloseReason::Banned,
         DisconnectReason::ConnectionLost => ConnectionCloseReason::ReaderExit,
         DisconnectReason::RemoteClosed => ConnectionCloseReason::ConnectionClosed,
+        DisconnectReason::LivenessTimeout => ConnectionCloseReason::LivenessTimeout,
     }
 }
 
@@ -6364,7 +6372,8 @@ impl P2pEndpoint {
             // Reviewer P1.1: this path previously bypassed the tracker, so
             // first-attempt successes between retry failures did not reset
             // the counter.
-            self.record_ack_liveness_signal(*peer_id, AckLivenessSignal::Success);
+            self.record_ack_liveness_signal(*peer_id, AckLivenessSignal::Success)
+                .await;
             return first;
         }
 
@@ -6374,7 +6383,8 @@ impl P2pEndpoint {
             self.record_ack_retry_outcome(*peer_id, AckOutcome::SenderRetryFailed);
             // No retry was actually attempted; treat as a single timeout
             // event for liveness purposes (no remote evidence either way).
-            self.record_ack_liveness_signal(*peer_id, AckLivenessSignal::RetryAckTimeout);
+            self.record_ack_liveness_signal(*peer_id, AckLivenessSignal::RetryAckTimeout)
+                .await;
             return first;
         }
 
@@ -6384,7 +6394,8 @@ impl P2pEndpoint {
         match retry {
             Ok(()) => {
                 self.record_ack_retry_outcome(*peer_id, AckOutcome::SenderRetryAccepted);
-                self.record_ack_liveness_signal(*peer_id, AckLivenessSignal::Success);
+                self.record_ack_liveness_signal(*peer_id, AckLivenessSignal::Success)
+                    .await;
                 Ok(())
             }
             Err(EndpointError::AckTimeout) => {
@@ -6392,7 +6403,8 @@ impl P2pEndpoint {
                 // Reviewer P1.2: only a true AckTimeout on the retry path
                 // signals half-dead. Non-timeout retry errors (handled in
                 // the next arm) prove the remote responded.
-                self.record_ack_liveness_signal(*peer_id, AckLivenessSignal::RetryAckTimeout);
+                self.record_ack_liveness_signal(*peer_id, AckLivenessSignal::RetryAckTimeout)
+                    .await;
                 Err(EndpointError::AckTimeout)
             }
             Err(error) => {
@@ -6400,7 +6412,8 @@ impl P2pEndpoint {
                 // X0X-0062 P1.2: the remote responded on retry with a
                 // non-timeout terminal outcome (Rejected, ConnectionClosed,
                 // invalid response). Path is alive — reset the tracker.
-                self.record_ack_liveness_signal(*peer_id, AckLivenessSignal::Success);
+                self.record_ack_liveness_signal(*peer_id, AckLivenessSignal::Success)
+                    .await;
                 Err(error)
             }
         }
@@ -6439,7 +6452,7 @@ impl P2pEndpoint {
     /// (`ReceiveRejected`, `ConnectionClosed`, `Connection`) prove the
     /// remote responded — the data path is alive, just rejecting this send.
     /// Those outcomes reset the tracker.
-    fn record_ack_liveness_signal(&self, peer_id: PeerId, signal: AckLivenessSignal) {
+    async fn record_ack_liveness_signal(&self, peer_id: PeerId, signal: AckLivenessSignal) {
         let connection = self.inner.get_connection(&peer_id).ok().flatten();
         let stable_id = match connection.as_ref() {
             Some(connection) => connection.stable_id(),
@@ -6453,7 +6466,8 @@ impl P2pEndpoint {
                 if self.ack_liveness.record_failure(peer_id, stable_id)
                     && let Some(connection) = connection
                 {
-                    self.trigger_liveness_close(peer_id, stable_id, &connection);
+                    self.trigger_liveness_close(peer_id, stable_id, &connection)
+                        .await;
                 }
             }
         }
@@ -6461,11 +6475,31 @@ impl P2pEndpoint {
 
     /// X0X-0062: force-close a connection whose data path is half-dead.
     /// Called when `AckLivenessTracker` confirms `LIVENESS_FAILURE_THRESHOLD`
-    /// consecutive ACK retry failures within `LIVENESS_FAILURE_WINDOW`. Emits
-    /// `Closing { LivenessTimeout } + Closed { LivenessTimeout }` lifecycle
-    /// events so application-layer races (e.g. x0x's X0X-0053 mid-send race)
-    /// can detect the close and re-dial on a fresh QUIC connection.
-    fn trigger_liveness_close(
+    /// consecutive ACK retry failures within `LIVENESS_FAILURE_WINDOW`.
+    ///
+    /// Reviewer P2 (round 2): the original implementation only emitted
+    /// `Closing/Closed{LivenessTimeout}` lifecycle events and called
+    /// `Connection::close()` directly. Quinn's local close became
+    /// `ConnectionError::LocallyClosed` in the connection-state machine, and
+    /// the connection itself remained in `connected_peers` until a later
+    /// reaper run — so `is_connected()` could still return true after the
+    /// liveness close, and any later `close_reason_from_connection` query
+    /// would downgrade the diagnostic from `LivenessTimeout` to
+    /// `LocallyClosed`. Now the trigger site invokes the existing
+    /// `cleanup_connection(DisconnectReason::LivenessTimeout)` helper, which
+    /// `close_reason_for_disconnect` maps to `LivenessTimeout`. That path:
+    /// 1. emits `Closing{LivenessTimeout}`
+    /// 2. calls `remove_connection_with_reason(LivenessTimeout)` on the
+    ///    inner NAT-traversal endpoint — removing the connection from the
+    ///    state map AND tagging the inner record with LivenessTimeout
+    /// 3. emits `Closed{LivenessTimeout}`
+    /// 4. fails any in-flight ACK waiters with `LivenessTimeout` close reason
+    /// 5. tears down reader handles + removes the peer from `connected_peers`
+    ///
+    /// Result: `is_connected(peer_id)` immediately returns false after the
+    /// trigger, and the LivenessTimeout reason is preserved everywhere
+    /// downstream rather than getting downgraded to LocallyClosed.
+    async fn trigger_liveness_close(
         &self,
         peer_id: PeerId,
         stable_id: usize,
@@ -6476,20 +6510,6 @@ impl P2pEndpoint {
             self.ack_liveness.forget(peer_id, stable_id);
             return;
         }
-        let reason = ConnectionCloseReason::LivenessTimeout;
-        // LivenessTimeout is guaranteed to have a reserved app error code
-        // by ConnectionCloseReason::app_error_code; if a future refactor
-        // drops the mapping, fall back to LifecycleCleanup (also lifecycle-
-        // reserved) and if that somehow returns None too, abandon the force-
-        // close rather than panic — the caller will retry on next failure
-        // and the assertion in the unit test would catch the regression.
-        let Some(code) = reason
-            .app_error_code()
-            .or_else(|| ConnectionCloseReason::LifecycleCleanup.app_error_code())
-        else {
-            self.ack_liveness.forget(peer_id, stable_id);
-            return;
-        };
         tracing::warn!(
             peer_id = %peer_id,
             stable_id = stable_id,
@@ -6499,24 +6519,17 @@ impl P2pEndpoint {
             LIVENESS_FAILURE_THRESHOLD,
             LIVENESS_FAILURE_WINDOW.as_secs(),
         );
-
-        // Emit Closing+Closed lifecycle events before invoking the actual
-        // close so observers see the LivenessTimeout reason — the generic
-        // close paths downstream may map the application-close code back to
-        // LivenessTimeout via from_app_error_code, but emitting here keeps the
-        // signal source-of-truth at the trigger site.
-        if let Some(generation) = self.peer_event_generations.read().get(&peer_id).copied() {
-            self.emit_peer_lifecycle_event(
-                peer_id,
-                PeerLifecycleEvent::Closing { generation, reason },
-            );
-            self.emit_peer_lifecycle_event(
-                peer_id,
-                PeerLifecycleEvent::Closed { generation, reason },
-            );
-        }
-        connection.close(code, reason.reason_bytes());
+        // Drop the tracker entry FIRST so a successful re-dial that lands on
+        // the same (peer, stable_id) — vanishingly unlikely but defensive —
+        // gets a clean slate.
         self.ack_liveness.forget(peer_id, stable_id);
+        // cleanup_connection is the source-of-truth disconnect path. With
+        // DisconnectReason::LivenessTimeout it threads LivenessTimeout through
+        // every layer: lifecycle events, inner state machine, ACK waiters,
+        // reader handles, connected_peers, stats, and the user-facing event
+        // channel. After this returns, `is_connected(peer_id)` is false.
+        self.cleanup_connection(&peer_id, DisconnectReason::LivenessTimeout)
+            .await;
     }
 
     async fn send_ack_exchange_once(
@@ -9018,6 +9031,48 @@ mod tests {
         }
         // And the very next failure tips the (fresh) threshold cleanly.
         assert!(tracker.record_failure(peer, stable_id));
+    }
+
+    /// X0X-0062 P2 (round 2) reviewer regression: `DisconnectReason::LivenessTimeout`
+    /// must thread `ConnectionCloseReason::LivenessTimeout` through the
+    /// `close_reason_for_disconnect` mapping consumed by `cleanup_connection`.
+    /// Without this mapping, `trigger_liveness_close`'s call to
+    /// `cleanup_connection(DisconnectReason::LivenessTimeout)` would still
+    /// invoke the do_cleanup_connection path — but the inner
+    /// `remove_connection_with_reason(close_reason)` would tag the connection
+    /// with the wrong reason, the `Closing/Closed` lifecycle events would
+    /// emit the wrong reason, and any downstream observer would see
+    /// LocallyClosed or LifecycleCleanup instead of the actual LivenessTimeout
+    /// signal. This test pins the mapping.
+    #[test]
+    fn disconnect_reason_liveness_timeout_maps_to_close_reason_liveness_timeout() {
+        assert_eq!(
+            close_reason_for_disconnect(&DisconnectReason::LivenessTimeout),
+            ConnectionCloseReason::LivenessTimeout,
+            "DisconnectReason::LivenessTimeout (used by trigger_liveness_close \
+             when the X0X-0062 detector fires) must thread LivenessTimeout \
+             through the disconnect-reason mapping consumed by \
+             cleanup_connection — otherwise the close-reason gets downgraded \
+             to LocallyClosed or LifecycleCleanup downstream and the \
+             LivenessTimeout signal is lost (reviewer P2 round 2)"
+        );
+        // And every other variant must NOT collide on LivenessTimeout (so a
+        // future-added variant can't accidentally map to LivenessTimeout and
+        // silently force-close peers).
+        for other in [
+            DisconnectReason::Normal,
+            DisconnectReason::Timeout,
+            DisconnectReason::ProtocolError("x".to_string()),
+            DisconnectReason::AuthenticationFailed,
+            DisconnectReason::ConnectionLost,
+            DisconnectReason::RemoteClosed,
+        ] {
+            assert_ne!(
+                close_reason_for_disconnect(&other),
+                ConnectionCloseReason::LivenessTimeout,
+                "only DisconnectReason::LivenessTimeout should map to ConnectionCloseReason::LivenessTimeout"
+            );
+        }
     }
 
     /// X0X-0062 P2 reviewer regression: `LivenessTimeout` must round-trip


### PR DESCRIPTION
## Summary

Reviewer round-2 finding: `trigger_liveness_close` emitted `Closing/Closed{LivenessTimeout}` lifecycle events and called `Connection::close()` directly, but the connection stayed in `connected_peers` until a later reaper. `is_connected(peer_id)` returned true after the liveness close, and `close_reason_from_connection` downgraded the diagnostic from `LivenessTimeout` to `LocallyClosed`. **Lifecycle state was emitted but not authoritative.**

## Fix

`trigger_liveness_close` now invokes the existing `cleanup_connection(DisconnectReason::LivenessTimeout)` helper, which threads `LivenessTimeout` through every layer: lifecycle events, `remove_connection_with_reason` on the inner state machine, ACK waiters, reader handles, and `connected_peers` removal.

Added `DisconnectReason::LivenessTimeout` variant + wired it through `close_reason_for_disconnect`, `link_transport_impl`, and `node_event`.

## Test plan

- [x] cargo fmt + clippy clean
- [x] cargo test --all-features --workspace: **2390 passed, 0 failed**
- [x] New unit test pinning disconnect-reason → close-reason mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a zombie-connection bug where `trigger_liveness_close` emitted lifecycle events and called `Connection::close()` directly, but the peer remained in `connected_peers` until a later reaper — so `is_connected()` could return `true` and the close reason was downgraded from `LivenessTimeout` to `LocallyClosed`. The fix routes through the existing `cleanup_connection(DisconnectReason::LivenessTimeout)` helper, which atomically removes the connection from all state maps, tears down reader handles, fails ACK waiters, and preserves the `LivenessTimeout` reason end-to-end.

- Added `DisconnectReason::LivenessTimeout` variant and wired it through `close_reason_for_disconnect`, `link_transport_impl`, and `node_event` (mapped to the generic `Timeout` on user-facing surfaces, with the precise reason preserved in lifecycle events).
- Converted `record_ack_liveness_signal` and `trigger_liveness_close` from sync to `async fn` to support the awaited `cleanup_connection` call.
- Added a unit test pinning the `DisconnectReason::LivenessTimeout → ConnectionCloseReason::LivenessTimeout` mapping.

<h3>Confidence Score: 4/5</h3>

The fix correctly eliminates the zombie-connection window by routing all teardown through cleanup_connection; safe to merge.

The core logic is sound: delegating to cleanup_connection ensures connected_peers, ACK waiters, and lifecycle events all see the same LivenessTimeout reason atomically. The one minor rough edge is that the connection parameter in trigger_liveness_close is vestigial after the refactor, but this does not affect correctness.

src/p2p_endpoint.rs around trigger_liveness_close — the connection parameter and its associated guard are dead code after this refactor.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | Core fix: trigger_liveness_close now delegates to cleanup_connection; new DisconnectReason::LivenessTimeout variant wired through close_reason_for_disconnect; record_ack_liveness_signal made async. The connection parameter in trigger_liveness_close is now only used for a guard that can never trigger by construction. |
| src/node_event.rs | New From arm maps P2pDisconnectReason::LivenessTimeout to the generic Timeout on the user-facing event surface; design choice is clearly documented. |
| src/link_transport_impl.rs | New match arm maps DisconnectReason::LivenessTimeout to DisconnectReason::Timeout in the transport event channel; mirrors the node_event.rs decision and is well-commented. |
| CHANGELOG.md | New 0.27.18 entry accurately describes the zombie-connection fix and the cleanup_connection delegation chain. |
| Cargo.toml | Version bump from 0.27.17 to 0.27.18, consistent with CHANGELOG and Cargo.lock. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Sender as send_with_ack
    participant Signal as record_ack_liveness_signal
    participant Trigger as trigger_liveness_close
    participant Cleanup as cleanup_connection / do_cleanup_connection
    participant Inner as NatTraversalEndpoint
    participant Events as PeerLifecycleEvent channel
    participant Peers as connected_peers

    Sender->>Signal: RetryAckTimeout
    Signal->>Signal: ack_liveness.record_failure()
    Note over Signal: threshold reached
    Signal->>Trigger: "trigger_liveness_close(peer_id, stable_id, &connection).await"
    Trigger->>Trigger: "guard: connection.stable_id() == stable_id?"
    Trigger->>Trigger: ack_liveness.forget(peer_id, stable_id)
    Trigger->>Cleanup: cleanup_connection(LivenessTimeout).await
    Cleanup->>Inner: get_connection(peer_id) to lifecycle_snapshot
    Cleanup->>Events: "Closing { LivenessTimeout }"
    Cleanup->>Inner: remove_connection_with_reason(LivenessTimeout)
    Cleanup->>Events: "Closed { LivenessTimeout }"
    Cleanup->>Cleanup: fail_ack_waiters_for_connection
    Cleanup->>Cleanup: tear down reader_handles
    Cleanup->>Peers: "remove_connected_peer, is_connected() = false"
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/p2p_endpoint.rs:6502-6512
The `connection` parameter to `trigger_liveness_close` is now only used in the early-exit guard `connection.stable_id() != stable_id`, but at every call site `stable_id` was just derived from `connection.stable_id()` (see `record_ack_liveness_signal`), so the guard is always false and the parameter carries no effective information. The `connection` object is never used in the cleanup path anymore — passing `stable_id` alone would be sufficient and makes the intent clearer.

```suggestion
    async fn trigger_liveness_close(
        &self,
        peer_id: PeerId,
        stable_id: usize,
    ) {
        // Guard against a stale stable_id by re-checking the live connection.
        let current_stable_id = self
            .inner
            .get_connection(&peer_id)
            .ok()
            .flatten()
            .map(|c| c.stable_id());
        if current_stable_id != Some(stable_id) {
            // Connection was already replaced; the tracker is stale.
            self.ack_liveness.forget(peer_id, stable_id);
            return;
        }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["release: ant-quic 0.27.18 — X0X-0062 rev..."](https://github.com/saorsa-labs/ant-quic/commit/8eaebbf9114f03ba2359524595f4873ee49e9755) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31570134)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->