### PR TITLE
test(mdns): add ignored local discovery runtime harness

### DIFF
--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -809,6 +809,89 @@ mod tests {
         ));
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "requires host mDNS responder/browser support on a real local interface"]
+    async fn test_mdns_runtime_discovers_advertised_peer_on_local_network()
+    -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let service = format!("ant-quic-test-{}", std::process::id());
+        let namespace = format!("workspace-{}", std::process::id());
+        let browser_peer = PeerId([0xd0; 32]);
+        let advertised_peer = PeerId([0xd1; 32]);
+        let advertised_port = 31_555;
+
+        let browser_shutdown = CancellationToken::new();
+        let advertiser_shutdown = CancellationToken::new();
+        let (events_tx, mut events_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let browser_config = MdnsConfig {
+            enabled: true,
+            service: Some(service.clone()),
+            namespace: Some(namespace.clone()),
+            mode: MdnsMode::BrowseOnly,
+            auto_connect: AutoConnectPolicy::Disabled,
+            metadata: BTreeMap::new(),
+        };
+        let advertiser_config = MdnsConfig {
+            enabled: true,
+            service: Some(service),
+            namespace: Some(namespace),
+            mode: MdnsMode::AdvertiseOnly,
+            auto_connect: AutoConnectPolicy::Disabled,
+            metadata: BTreeMap::new(),
+        };
+
+        let browser_task = tokio::spawn(run_mdns_runtime(
+            browser_config,
+            browser_peer,
+            0,
+            browser_shutdown.clone(),
+            move |event| {
+                let _ = events_tx.send(event);
+            },
+        ));
+
+        let advertiser_task = tokio::spawn(run_mdns_runtime(
+            advertiser_config,
+            advertised_peer,
+            advertised_port,
+            advertiser_shutdown.clone(),
+            |_| {},
+        ));
+
+        let discovered = tokio::time::timeout(Duration::from_secs(15), async {
+            while let Some(event) = events_rx.recv().await {
+                match event {
+                    MdnsRuntimeEvent::PeerDiscovered(peer)
+                    | MdnsRuntimeEvent::PeerUpdated(peer)
+                    | MdnsRuntimeEvent::PeerEligible(peer)
+                        if peer.claimed_peer_id == Some(advertised_peer)
+                            && peer
+                                .addresses
+                                .iter()
+                                .any(|addr| addr.port() == advertised_port) =>
+                    {
+                        return true;
+                    }
+                    _ => {}
+                }
+            }
+            false
+        })
+        .await
+        .unwrap_or(false);
+
+        browser_shutdown.cancel();
+        advertiser_shutdown.cancel();
+        let _ = tokio::time::timeout(Duration::from_secs(5), browser_task).await;
+        let _ = tokio::time::timeout(Duration::from_secs(5), advertiser_task).await;
+
+        assert!(
+            discovered,
+            "browser did not discover advertised mDNS peer on the local network"
+        );
+        Ok(())
+    }
+
     #[test]
     fn test_advertised_metadata_preserves_user_entries_and_overrides_reserved_keys() {
         let local_peer_id = PeerId([0xcc; 32]);

--- a/tests/pqc_basic_integration.rs
+++ b/tests/pqc_basic_integration.rs
@@ -55,10 +55,9 @@ fn assert_ml_dsa_peer_identity(
         "rustls peer identity should be certificate/SPKI bytes"
     );
 
-    let certs = match identity.downcast::<Vec<CertificateDer<'static>>>() {
-        Ok(certs) => certs,
-        Err(_) => panic!("peer identity type checked above"),
-    };
+    let certs_result = identity.downcast::<Vec<CertificateDer<'static>>>();
+    assert!(certs_result.is_ok(), "peer identity type checked above");
+    let certs = certs_result.unwrap_or_default();
     let spki = certs
         .first()
         .expect("peer identity should contain an ML-DSA-65 SPKI");

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -170,7 +170,7 @@ where
         }
         sleep(Duration::from_millis(20)).await;
     }
-    panic!("condition not met within {timeout:?}");
+    assert!(check(), "condition not met within {timeout:?}");
 }
 
 pub fn lifecycle_generations_for_peer(peer_id: PeerId) -> Vec<u64> {


### PR DESCRIPTION
## Summary
- adds an ignored/manual mDNS runtime harness that runs a local browser and advertiser against the host mDNS stack
- keeps the test out of default CI because it depends on local-network/mDNS responder support
- fixes strict clippy test helpers so the PR can be validated with the repository's panic/unwrap/expect policy

Addresses #189.

Note: #190 already has substantial mock IGD coverage in src/port_mapping.rs, so this PR intentionally does not add more UPnP changes.

## Validation
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features
- cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
- cargo test --lib mdns::tests::test_mdns_runtime_discovers_advertised_peer_on_local_network -- --ignored --list

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a manual/ignored mDNS integration harness that exercises the real OS mDNS stack end-to-end, and brings two existing test helpers into compliance with the repository's strict clippy panic/unwrap/expect policy.

- **`src/mdns.rs`**: New `#[ignore]` async test spawns a `BrowseOnly` and an `AdvertiseOnly` mDNS runtime, waits up to 15 s for discovery, then cancels and joins both tasks. Process-ID-scoped service and namespace names prevent cross-process interference.
- **`tests/pqc_basic_integration.rs`**: Replaces `panic!` (banned by `-D clippy::panic`) with `assert!(is_ok()) + unwrap_or_default()`. File-level `#![allow(clippy::unwrap_used)]` already permits plain `.unwrap()`, so the `_or_default` variant is more conservative than required.
- **`tests/support/mod.rs`**: Replaces unconditional `panic!` at the `wait_until` timeout boundary with `assert!(check(), ...)`, adding one final predicate evaluation instead of an immediate failure.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all three changes are additive or narrowly scoped to test helpers and cannot affect production code paths.

The mDNS harness is correctly guarded with `#[ignore]` and will never run in CI. The `wait_until` change makes one extra predicate call on timeout, a deliberate and benign semantic shift. The `unwrap_or_default()` in the PQC test is harmless but misleading given the file-level allow already permits `.unwrap()`.

tests/pqc_basic_integration.rs — the `unwrap_or_default()` after `assert!(is_ok())` is worth a quick second look.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/mdns.rs | Adds an `#[ignore]` async integration test that spawns a real mDNS browser and advertiser against the host mDNS stack; cleanly structured with cancellation, timeout, and graceful shutdown. |
| tests/pqc_basic_integration.rs | Replaces `panic!` with `assert!(is_ok()) + unwrap_or_default()` to satisfy `-D clippy::panic`; file already has `#![allow(clippy::unwrap_used)]` so the `unwrap_or_default()` workaround is slightly more conservative than needed, but functionally correct. |
| tests/support/mod.rs | Changes `panic!` to `assert!(check(), ...)` in `wait_until`, introducing a subtle semantic change: one extra predicate evaluation after the timeout loop rather than an unconditional failure. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as test harness
    participant BT as browser_task
    participant AT as advertiser_task
    participant mDNS as host mDNS stack
    participant CH as events channel

    Test->>BT: "spawn run_mdns_runtime(BrowseOnly, port=0)"
    Test->>AT: "spawn run_mdns_runtime(AdvertiseOnly, port=31555)"
    AT->>mDNS: register service record
    BT->>mDNS: browse for service type
    mDNS-->>BT: service resolved
    BT->>CH: MdnsRuntimeEvent::PeerDiscovered/Updated/Eligible
    Test->>CH: recv events (15s timeout)
    CH-->>Test: "event matches advertised_peer && port==31555"
    Test->>BT: browser_shutdown.cancel()
    Test->>AT: advertiser_shutdown.cancel()
    Test->>BT: timeout(5s) join
    Test->>AT: timeout(5s) join
    Test->>Test: assert!(discovered)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
tests/pqc_basic_integration.rs:58-60
Unnecessary two-step workaround — `unwrap()` is already allowed here. The file-level `#![allow(clippy::unwrap_used)]` on line 7 means `.unwrap()` won't be flagged. Using `unwrap_or_default()` is misleading because the empty-Vec default is not a valid state: the very next line calls `.first().expect(...)` and would produce a confusing error message if the default were somehow used.

```suggestion
    let certs_result = identity.downcast::<Vec<CertificateDer<'static>>>();
    assert!(certs_result.is_ok(), "peer identity type checked above");
    let certs = certs_result.unwrap();
```

### Issue 2 of 2
tests/support/mod.rs:173
Subtle semantic change worth documenting. The original code panicked unconditionally on timeout; the replacement calls `check()` one additional time after the loop exits. For the typical idempotent predicate this is fine (and actually better — it avoids a false failure when the condition is met during the final 20 ms sleep). However, because `check` is `FnMut` it could have observable side effects, so callers should be aware the predicate may fire one extra time on the timeout path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(mdns): add ignored local discovery ..."](https://github.com/saorsa-labs/ant-quic/commit/c06b2f0bf9481b2491c1c48a1d945d0d4b4b3c7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34349826)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->