### PR TITLE
fix(ci): forward writable TMPDIR into aarch64 cross test container

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -36,6 +36,11 @@ pre-build = [
 [target.aarch64-unknown-linux-gnu.env]
 passthrough = [
     "PKG_CONFIG_ALLOW_CROSS=1",
+    # Give the emulated test binary a writable cache dir. Without this the
+    # container has no writable TMPDIR/HOME, so default_cache_dir() falls back
+    # to a read-only path and BootstrapCache::open() fails with EACCES,
+    # panicking every endpoint-constructing test (see bootstrap_cache::config).
+    "TMPDIR=/tmp",
 ]
 
 # ARM64 MUSL static builds


### PR DESCRIPTION
## Problem

The weekly **Platforms** workflow's `aarch64-unknown-linux-gnu / stable` job has failed every run for over a month (05-04, 05-11, 05-18, 05-25, 06-01). 37 lib tests panic with:

```
Failed to open bootstrap cache: Permission denied (os error 13)
```

All 37 failures share this single root cause (the rest of the suite — 2574 tests — passes).

## Root cause

Under `cross test`, the lib tests run inside a Docker/QEMU container. `default_cache_dir()` (`src/bootstrap_cache/config.rs`) prefers `TMPDIR` "for sandbox compatibility", and `platforms.yml` sets `TMPDIR=/tmp` on the step — **but that env var lives on the host `cross` process, and `cross` does not forward arbitrary host env into the container.**

The `aarch64-unknown-linux-gnu` passthrough list only carried `PKG_CONFIG_ALLOW_CROSS=1`, so inside the container `TMPDIR` was unset, the cache dir fell back to a non-writable path, and `BootstrapCache::open()` → `create_dir_all()` failed with `EACCES`, panicking every endpoint-constructing test.

The native x86_64 Linux job was unaffected because it runs directly on the runner where `TMPDIR`/`HOME` are writable.

## Fix

Add an explicit `TMPDIR=/tmp` to the `aarch64-unknown-linux-gnu` passthrough in `Cross.toml` so the emulated test binary always has a writable cache dir. Self-contained (does not rely on the step env), fixes all 37 failures at the source. One-line CI-config change; no production code touched.

## Verification

Docker isn't available locally to run `cross`, so this PR's **Platforms** check (the `pull_request` trigger has no path filter) is the verification — the `aarch64-unknown-linux-gnu / stable` job should now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `TMPDIR=/tmp` to the `aarch64-unknown-linux-gnu` passthrough list in `Cross.toml`, ensuring the QEMU-emulated test container always has a writable cache directory. The root cause — `BootstrapCache::open()` failing with `EACCES` in every endpoint-constructing test — is correctly addressed at its source without touching production code.

- The `VAR=VALUE` passthrough syntax is officially documented by cross-rs and consistent with existing entries like `OPENSSL_STATIC=1` already present in the file.
- The `armv7-unknown-linux-gnueabihf` target uses the same QEMU-emulated container pattern but does not yet have `TMPDIR` forwarded; if its test suite exercises `BootstrapCache`, it would hit the same failure.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the one-line change directly targets the documented root cause of 37 recurring test failures in the aarch64 CI job.

The fix is minimal and correct — the VAR=VALUE passthrough syntax is officially supported by cross-rs and consistent with existing entries in the file. The only open question is whether the armv7-unknown-linux-gnueabihf target warrants the same treatment, but that is a separate concern that does not block this change.

No files require special attention beyond the suggestion to consider armv7-unknown-linux-gnueabihf consistency.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cross.toml | Adds TMPDIR=/tmp to the aarch64-unknown-linux-gnu passthrough list so the emulated test container has a writable cache dir; uses the correct cross VAR=VALUE passthrough syntax (confirmed in cross docs). Other QEMU-emulated targets (armv7-unknown-linux-gnueabihf) carry the same passthrough gap if they run tests. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CI as GitHub Actions
    participant cross as cross (host)
    participant container as Docker/QEMU Container
    participant test as Test Binary

    Note over CI,test: Before this PR
    CI->>cross: "run `cross test` (TMPDIR=/tmp on host)"
    cross->>container: start container (TMPDIR not forwarded)
    container->>test: execute tests (TMPDIR unset)
    test->>test: default_cache_dir() → fallback path
    test-->>CI: EACCES panic (37 failures)

    Note over CI,test: After this PR
    CI->>cross: run `cross test`
    cross->>container: "start container (TMPDIR=/tmp via passthrough)"
    container->>test: "execute tests (TMPDIR=/tmp)"
    test->>test: default_cache_dir() → /tmp/...
    test-->>CI: all 37 tests pass
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Cross.toml`, line 62-65 ([link](https://github.com/saorsa-labs/ant-quic/blob/77283eef1f8264f2d97c8598cfa6d16edf93aa23/Cross.toml#L62-L65)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `armv7-unknown-linux-gnueabihf` target also runs inside a QEMU-emulated container with the same cross image pattern. If `BootstrapCache` tests are exercised there, it will hit the same `EACCES` path, since its passthrough list also lacks `TMPDIR`. If the armv7 job currently skips those tests this is moot, but it may be worth aligning the two targets now.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Cross.toml
   Line: 62-65

   Comment:
   The `armv7-unknown-linux-gnueabihf` target also runs inside a QEMU-emulated container with the same cross image pattern. If `BootstrapCache` tests are exercised there, it will hit the same `EACCES` path, since its passthrough list also lacks `TMPDIR`. If the armv7 job currently skips those tests this is moot, but it may be worth aligning the two targets now.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Cross.toml:62-65
The `armv7-unknown-linux-gnueabihf` target also runs inside a QEMU-emulated container with the same cross image pattern. If `BootstrapCache` tests are exercised there, it will hit the same `EACCES` path, since its passthrough list also lacks `TMPDIR`. If the armv7 job currently skips those tests this is moot, but it may be worth aligning the two targets now.

```suggestion
[target.armv7-unknown-linux-gnueabihf.env]
passthrough = [
    "PKG_CONFIG_ALLOW_CROSS=1",
    "TMPDIR=/tmp",
]
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): forward writable TMPDIR into aa..."](https://github.com/saorsa-labs/ant-quic/commit/77283eef1f8264f2d97c8598cfa6d16edf93aa23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35992789)</sub>

<!-- /greptile_comment -->