### PR TITLE
fix(endpoint): release UDP socket on shutdown

### DIFF
--- a/src/high_level/endpoint.rs
+++ b/src/high_level/endpoint.rs
@@ -436,6 +436,61 @@ impl Endpoint {
             .local_addr()
     }
 
+    /// Replace the endpoint's UDP socket with an ephemeral loopback socket.
+    ///
+    /// This is used during explicit shutdown to synchronously release the
+    /// externally visible bind port while the `Endpoint` handle itself may stay
+    /// alive in an embedding process. Unlike `rebind_abstract`, this deliberately
+    /// clears `prev_socket` so the old socket is dropped immediately rather than
+    /// retained until migration traffic arrives on the replacement socket.
+    #[cfg(not(wasm_browser))]
+    pub(crate) fn release_socket_for_shutdown(&self) -> io::Result<()> {
+        let (old_addr, runtime) = {
+            let state = self
+                .inner
+                .state
+                .lock()
+                .map_err(|_| io::Error::other("Endpoint state mutex poisoned"))?;
+            if state.socket_released_for_shutdown {
+                return Ok(());
+            }
+            (state.socket.local_addr()?, state.runtime.clone())
+        };
+
+        let replacement_addr = if old_addr.is_ipv6() {
+            SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, 0))
+        } else {
+            SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 0))
+        };
+
+        let replacement = std::net::UdpSocket::bind(replacement_addr).or_else(|first_error| {
+            if old_addr.is_ipv6() {
+                let fallback_addr = SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 0));
+                std::net::UdpSocket::bind(fallback_addr)
+            } else {
+                Err(first_error)
+            }
+        })?;
+        replacement.set_nonblocking(true)?;
+        let replacement = runtime.wrap_udp_socket(replacement)?;
+        let replacement_addr = replacement.local_addr()?;
+
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| io::Error::other("Endpoint state mutex poisoned"))?;
+        if state.socket_released_for_shutdown {
+            return Ok(());
+        }
+        state.prev_socket = None;
+        state.socket = replacement;
+        state.ipv6 = replacement_addr.is_ipv6();
+        state.socket_released_for_shutdown = true;
+
+        Ok(())
+    }
+
     /// Get the number of connections that are currently open
     pub fn open_connections(&self) -> usize {
         self.inner
@@ -681,6 +736,7 @@ pub(crate) struct State {
     stats: EndpointStats,
     /// Channel for forwarding peer address updates to the upper layer.
     peer_address_update_tx: Option<mpsc::UnboundedSender<(SocketAddr, SocketAddr)>>,
+    socket_released_for_shutdown: bool,
 }
 
 #[derive(Debug)]
@@ -934,6 +990,7 @@ impl EndpointRef {
                 runtime,
                 stats: EndpointStats::default(),
                 peer_address_update_tx: None,
+                socket_released_for_shutdown: false,
             }),
         }))
     }

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -7824,6 +7824,11 @@ impl NatTraversalEndpoint {
             {
                 info!("wait_idle timed out during shutdown, proceeding");
             }
+
+            #[cfg(not(wasm_browser))]
+            if let Err(error) = endpoint.release_socket_for_shutdown() {
+                warn!(%error, "failed to release endpoint UDP socket during shutdown");
+            }
         }
 
         // Wait for transport listener tasks to complete

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -2834,7 +2834,7 @@ impl P2pEndpoint {
         )
         .await
         {
-            Ok((transport, dual_socket)) => {
+            Ok((_transport, dual_socket)) => {
                 let (v4_addr, v6_addr) = dual_socket.local_addrs();
                 info!(
                     "Bound dual-socket: IPv4={}, IPv6={} (true dual-stack, separate sockets)",
@@ -2850,10 +2850,12 @@ impl P2pEndpoint {
                     EndpointError::Config(format!("Failed to get local address: {e}"))
                 })?;
 
-                // Create transport registry
+                // Create transport registry. Do not register the QUIC UDP socket
+                // itself: the high-level endpoint owns that socket directly, and
+                // retaining a registry clone would keep a fixed bind port alive
+                // after `shutdown()` in long-lived embedding processes.
                 let mut transport_registry = config.transport_registry.clone();
                 crate::transport::register_best_effort_transports(&mut transport_registry).await;
-                transport_registry.register(Arc::new(transport));
 
                 nat_config.transport_registry = Some(Arc::new(transport_registry));
                 nat_config.bind_addr = Some(actual_bind_addr);
@@ -2894,7 +2896,7 @@ impl P2pEndpoint {
                     .and_then(|addr| addr.as_socket_addr())
                     .unwrap_or(dual_stack_default);
 
-                let (transport, quinn_socket) =
+                let (_transport, quinn_socket) =
                     match crate::transport::UdpTransport::bind_for_quinn(bind_addr).await {
                         Ok(result) => result,
                         Err(e2) if bind_addr == dual_stack_default => {
@@ -2928,9 +2930,12 @@ impl P2pEndpoint {
                     }
                 );
 
+                // Do not register the QUIC UDP socket itself: the high-level
+                // endpoint owns that socket directly, and retaining a registry
+                // clone would keep a fixed bind port alive after `shutdown()` in
+                // long-lived embedding processes.
                 let mut transport_registry = config.transport_registry.clone();
                 crate::transport::register_best_effort_transports(&mut transport_registry).await;
-                transport_registry.register(Arc::new(transport));
 
                 nat_config.transport_registry = Some(Arc::new(transport_registry));
                 nat_config.bind_addr = Some(actual_bind_addr);
@@ -10757,24 +10762,24 @@ mod tests {
     async fn test_p2p_endpoint_stores_transport_registry() {
         use crate::transport::TransportType;
 
-        // Build config with default transport providers
-        // Phase 5.3: P2pEndpoint::new() always adds a shared UDP transport
+        // Build config with default transport providers. The QUIC UDP socket is
+        // owned by the high-level endpoint, not retained as a registry provider,
+        // so shutdown can release fixed bind ports.
         let config = P2pConfig::builder().build().expect("valid config");
 
         // Create endpoint
         let result = P2pEndpoint::new(config).await;
 
-        // Verify registry is accessible and contains the auto-added UDP provider
+        // Verify registry is accessible but does not retain the QUIC UDP socket.
         if let Ok(endpoint) = result {
             let registry = endpoint.transport_registry();
-            // Phase 5.3: Registry now always has at least 1 UDP provider (socket sharing)
-            assert!(
-                !registry.is_empty(),
-                "Registry should have at least 1 provider"
-            );
-
             let udp_providers = registry.providers_by_type(TransportType::Udp);
-            assert_eq!(udp_providers.len(), 1, "Should have 1 UDP provider");
+            assert_eq!(
+                udp_providers.len(),
+                0,
+                "QUIC UDP socket should not be retained by the transport registry"
+            );
+            endpoint.shutdown().await;
         }
         // Note: endpoint creation may fail in test environment without network
     }
@@ -10787,20 +10792,82 @@ mod tests {
         // Create endpoint
         let result = P2pEndpoint::new(config).await;
 
-        // Phase 5.3: Default registry now includes a shared UDP transport
-        // This is required for socket sharing with Quinn
+        // The default registry may be empty: the QUIC UDP socket is owned by
+        // the high-level endpoint so explicit shutdown can release it.
         if let Ok(endpoint) = result {
             let registry = endpoint.transport_registry();
             assert!(
-                !registry.is_empty(),
-                "Default registry should have UDP for socket sharing"
+                !registry.has_quic_capable_transport(),
+                "Default registry should not retain the QUIC UDP socket"
             );
-            assert!(
-                registry.has_quic_capable_transport(),
-                "Default registry should have QUIC-capable transport"
-            );
+            endpoint.shutdown().await;
         }
         // Note: endpoint creation may fail in test environment without network
+    }
+
+    fn allocate_loopback_port() -> SocketAddr {
+        let probe = std::net::UdpSocket::bind(SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 0)))
+            .expect("allocate probe port");
+        let requested_addr = probe.local_addr().expect("probe local addr");
+        drop(probe);
+        requested_addr
+    }
+
+    async fn fixed_port_endpoint(requested_addr: SocketAddr) -> P2pEndpoint {
+        let config = P2pConfig::builder()
+            .bind_addr(requested_addr)
+            .port_mapping_enabled(false)
+            .build()
+            .expect("valid config");
+
+        P2pEndpoint::new(config).await.expect("endpoint starts")
+    }
+
+    #[tokio::test]
+    async fn shutdown_releases_udp_socket_for_same_process_rebind() {
+        let endpoint = fixed_port_endpoint(allocate_loopback_port()).await;
+        let local_addr = endpoint.local_addr().expect("endpoint local addr");
+
+        endpoint.shutdown().await;
+
+        let rebound = std::net::UdpSocket::bind(local_addr);
+        assert!(
+            rebound.is_ok(),
+            "shutdown should release {local_addr} for immediate same-process rebind while endpoint handle remains alive: {rebound:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_releases_multiple_fixed_udp_sockets_and_is_idempotent() {
+        let first = fixed_port_endpoint(allocate_loopback_port()).await;
+        let second = fixed_port_endpoint(allocate_loopback_port()).await;
+        let first_addr = first.local_addr().expect("first endpoint local addr");
+        let second_addr = second.local_addr().expect("second endpoint local addr");
+
+        assert!(
+            std::net::UdpSocket::bind(first_addr).is_err(),
+            "first fixed port should be held during steady state"
+        );
+        assert!(
+            std::net::UdpSocket::bind(second_addr).is_err(),
+            "second fixed port should be held during steady state"
+        );
+
+        first.shutdown().await;
+        first.shutdown().await;
+        second.shutdown().await;
+        second.shutdown().await;
+
+        let first_rebound = std::net::UdpSocket::bind(first_addr);
+        let second_rebound = std::net::UdpSocket::bind(second_addr);
+        assert!(
+            first_rebound.is_ok(),
+            "first fixed port should be immediately rebindable after idempotent shutdown: {first_rebound:?}"
+        );
+        assert!(
+            second_rebound.is_ok(),
+            "second fixed port should be immediately rebindable after idempotent shutdown: {second_rebound:?}"
+        );
     }
 
     #[tokio::test]

--- a/tests/transport_registry_flow.rs
+++ b/tests/transport_registry_flow.rs
@@ -74,19 +74,20 @@ async fn test_transport_registry_flows_from_node_config_to_p2p_endpoint() {
         !registry.is_empty(),
         "Registry should not be empty after wiring"
     );
-    // The registry contains our externally-registered provider PLUS the internal
-    // UDP transport created by P2pEndpoint for Quinn socket sharing.
+    // The registry contains externally-registered providers only. The QUIC UDP
+    // socket is owned by the high-level endpoint and is deliberately not exposed
+    // as a registry provider, so explicit shutdown can release fixed bind ports.
     assert_eq!(
         registry.len(),
-        2,
-        "Registry should have 2 providers (internal + external)"
+        1,
+        "Registry should have 1 external provider"
     );
 
     let udp_providers = registry.providers_by_type(TransportType::Udp);
     assert_eq!(
         udp_providers.len(),
-        2,
-        "Should have 2 UDP providers (internal + external)"
+        1,
+        "Should have 1 external UDP provider"
     );
 
     // Cleanup
@@ -126,12 +127,13 @@ async fn test_multiple_transport_providers_flow() {
         .await
         .expect("Node::with_config should succeed");
 
-    // Verify both providers are in the registry (+ the internal UDP transport = 3 total)
+    // Verify both externally configured providers are in the registry. The
+    // endpoint-owned QUIC UDP socket is intentionally not retained here.
     let registry = node.transport_registry();
     assert_eq!(
         registry.len(),
-        3,
-        "Registry should have 3 providers (internal + 2 external)"
+        2,
+        "Registry should have 2 external providers"
     );
 
     node.shutdown().await;


### PR DESCRIPTION
## Summary
- release the high-level endpoint UDP socket during explicit shutdown by replacing it with an ephemeral loopback socket
- avoid retaining the QUIC UDP socket through the default transport registry
- add a regression test proving immediate same-process fixed-port rebind while the endpoint handle remains alive

Closes #196.

## Validation
- cargo test shutdown_releases_udp_socket_for_same_process_rebind -- --nocapture
- cargo fmt --all
- cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
- cargo check --workspace --all-targets

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the QUIC UDP socket's bind port was retained after explicit shutdown because the transport registry held a cloned file descriptor. The fix has two parts: `release_socket_for_shutdown()` atomically swaps the live socket for an ephemeral loopback socket while the `Endpoint` handle is still alive, and the QUIC UDP transport is no longer registered in the transport registry so no external `Arc` can resurrect the port.

- `src/high_level/endpoint.rs`: adds `release_socket_for_shutdown()` with double-checked locking around the socket swap and a `socket_released_for_shutdown` idempotency guard; the synchronous (non-async) nature ensures it cannot be preempted by the outer `P2pEndpoint` shutdown timeout.
- `src/p2p_endpoint.rs`: drops the `UdpTransport` registry entry in both the single-socket and dual-stack bind paths; socket ownership stays exclusively with Quinn's endpoint, enabling clean release; includes a new regression test that verifies same-process port rebind immediately after shutdown.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the shutdown path correctly releases the UDP socket in all timing scenarios and the transport registry change is well-contained.

The core socket-swap logic is sound: `release_socket_for_shutdown` is synchronous so it cannot be cancelled mid-execution by the async timeout in `P2pEndpoint::shutdown`, the double-checked locking makes the call idempotent, and `bind_for_quinn` / `bind_dual_stack_for_endpoint` both clone the fd before returning it to Quinn so dropping `_transport` is safe. The one non-critical concern is the probe-drop-bind TOCTOU window in the new regression test.

The regression test in `src/p2p_endpoint.rs` (`shutdown_releases_udp_socket_for_same_process_rebind`) uses a bind/drop/rebind pattern that has a small port-stealing window; worth monitoring for flakiness in CI.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/high_level/endpoint.rs | Adds `release_socket_for_shutdown()` with double-checked locking to swap the bound UDP socket for an ephemeral loopback socket; adds `socket_released_for_shutdown` guard field; implementation is correct and idempotent. |
| src/nat_traversal_api.rs | Calls `release_socket_for_shutdown()` synchronously (no await) after `wait_idle` in the shutdown path; placement before the next await point ensures it runs even if the outer `P2pEndpoint` timeout expires. |
| src/p2p_endpoint.rs | Removes QUIC UDP socket from transport registry in both code paths; updates two tests to expect zero UDP providers; adds regression test that probes a port with bind/drop then expects rebind after shutdown — the probe-drop-rebind window is a minor TOCTOU risk. |

</details>


</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PE as P2pEndpoint
    participant NTE as NatTraversalEndpoint
    participant EP as high_level::Endpoint
    participant OS as OS / UDP Stack

    PE->>NTE: shutdown() [timeout 5s]
    NTE->>NTE: close all connections
    NTE->>EP: wait_idle() [timeout 5s]
    EP-->>NTE: idle (or timeout)
    NTE->>EP: release_socket_for_shutdown() [sync]
    Note over EP: lock state, read old_addr + runtime
    EP->>OS: bind(loopback:0) → replacement socket
    EP->>EP: lock state again, swap socket, set flag
    OS-->>EP: old socket fd released
    EP-->>NTE: Ok(())
    NTE->>NTE: wait for transport listener tasks [timeout 5s]
    NTE-->>PE: Ok(())
    Note over OS: original bind port now free for rebind
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PE as P2pEndpoint
    participant NTE as NatTraversalEndpoint
    participant EP as high_level::Endpoint
    participant OS as OS / UDP Stack

    PE->>NTE: shutdown() [timeout 5s]
    NTE->>NTE: close all connections
    NTE->>EP: wait_idle() [timeout 5s]
    EP-->>NTE: idle (or timeout)
    NTE->>EP: release_socket_for_shutdown() [sync]
    Note over EP: lock state, read old_addr + runtime
    EP->>OS: bind(loopback:0) → replacement socket
    EP->>EP: lock state again, swap socket, set flag
    OS-->>EP: old socket fd released
    EP-->>NTE: Ok(())
    NTE->>NTE: wait for transport listener tasks [timeout 5s]
    NTE-->>PE: Ok(())
    Note over OS: original bind port now free for rebind
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/p2p_endpoint.rs`, line 10809-10836 ([link](https://github.com/saorsa-labs/ant-quic/blob/cee1e30412a7a4cc480ea3048cc4daa88908f84c/src/p2p_endpoint.rs#L10809-L10836)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **TOCTOU window in port-probe pattern**

   Between `drop(probe)` and `P2pEndpoint::new(config).await` there is a brief window where the OS could assign `requested_addr` to another process. On a quiet CI machine this is vanishingly unlikely, but on a heavily loaded host the test can flake with `"endpoint starts"` failing because the port was stolen. A common mitigation is to leave the probe socket open, pass its raw fd to the endpoint, or use `SO_REUSEPORT` — though in practice the window is so small that most projects accept the risk in regression tests like this one.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/p2p_endpoint.rs
   Line: 10809-10836

   Comment:
   **TOCTOU window in port-probe pattern**

   Between `drop(probe)` and `P2pEndpoint::new(config).await` there is a brief window where the OS could assign `requested_addr` to another process. On a quiet CI machine this is vanishingly unlikely, but on a heavily loaded host the test can flake with `"endpoint starts"` failing because the port was stolen. A common mitigation is to leave the probe socket open, pass its raw fd to the endpoint, or use `SO_REUSEPORT` — though in practice the window is so small that most projects accept the risk in regression tests like this one.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/p2p_endpoint.rs:10809-10836
**TOCTOU window in port-probe pattern**

Between `drop(probe)` and `P2pEndpoint::new(config).await` there is a brief window where the OS could assign `requested_addr` to another process. On a quiet CI machine this is vanishingly unlikely, but on a heavily loaded host the test can flake with `"endpoint starts"` failing because the port was stolen. A common mitigation is to leave the probe socket open, pass its raw fd to the endpoint, or use `SO_REUSEPORT` — though in practice the window is so small that most projects accept the risk in regression tests like this one.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(endpoint): release UDP socket on shu..."](https://github.com/saorsa-labs/ant-quic/commit/cee1e30412a7a4cc480ea3048cc4daa88908f84c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38811540)</sub>

<!-- /greptile_comment -->