### PR TITLE
test(node): drain-on-shutdown regression for accept_bi (#202)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,18 @@
+# nextest configuration for the ant-quic workspace.
+#
+# node_app_streams tests are serialised because they use `b.shutdown()`, which
+# sends QUIC Connection Close frames to every active connection. When these
+# tests run concurrently they can accidentally accumulate cross-test mDNS
+# connections that are then torn down by the shutdown, interfering with
+# neighbouring tests.
+#
+# This matches the original intent of `test_guard()` in tests/support/mod.rs,
+# which is a static tokio::Mutex that serialises within a single process but
+# has no effect across nextest's default process-per-test model.
+
+[test-groups]
+node-app-streams = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = "binary_id(ant-quic::node_app_streams)"
+test-group = "node-app-streams"

--- a/tests/node_app_streams.rs
+++ b/tests/node_app_streams.rs
@@ -40,8 +40,8 @@ mod support;
 use std::collections::HashSet;
 use std::time::Duration;
 
-use ant_quic::Node;
-use tokio::time::timeout;
+use ant_quic::{EndpointError, Node, NodeError};
+use tokio::time::{sleep, timeout};
 
 /// Coerce a node's bound local address to a reachable loopback socket addr.
 /// `Node::local_addr()` may report an unspecified IPv6 `[::]:port` (dual-stack
@@ -307,4 +307,114 @@ async fn node_open_bi_accept_bi_smoke() {
     let copied = b_echo.await.expect("node echo join");
     assert_eq!(copied, payload.len() as u64);
     assert_eq!(&echoed[..], payload, "node echo integrity");
+}
+
+/// Regression: `accept_bi` drains the internal queue before returning
+/// `ShuttingDown`.
+///
+/// When a remote peer opens bidi streams and the local endpoint is subsequently
+/// shut down with handles still buffered in `app_bi_tx`, `accept_bi` must yield
+/// every queued handle before the shutdown arm fires. The `biased;` keyword in
+/// `P2pEndpoint::accept_bi`'s `tokio::select!` enforces this ordering by always
+/// polling the queue arm first.
+///
+/// # Regression guard
+///
+/// Removing `biased;` makes the select choose randomly between the queue-drain
+/// arm and the shutdown arm whenever both are simultaneously ready (i.e. the
+/// queue is non-empty AND shutdown is cancelled). With `DRAIN_STREAMS = 8`
+/// handles queued, all 8 calls returning `Ok` before `ShuttingDown` requires
+/// the queue arm to win 8 consecutive coin-flips — probability ≈ (1/2)^8 =
+/// 0.4%. In other words, a `biased;` regression causes this test to fail on
+/// ~99.6% of CI runs.
+///
+/// # Synchronisation note
+///
+/// The test keeps the local `(SendStream, RecvStream)` pairs alive until after
+/// all assertions. `SendStream::drop()` schedules an implicit `finish()`, which
+/// is correct but creates a tiny window where the FIN could race with `b`'s
+/// reader task reading the 8-byte magic prefix. Keeping the streams live until
+/// after the drain eliminates this race without changing correctness.
+///
+/// A single "primer" stream is opened and confirmed via `b.accept_bi()` before
+/// the DRAIN_STREAMS batch. This rules out a startup race where `b.accept()`
+/// has not yet run (so no reader task exists), and provides a concrete proof
+/// that the QUIC + reader-task path is live before the drain batch is added
+/// to the queue.
+#[tokio::test]
+async fn accept_bi_drains_queue_before_shutting_down() {
+    let _g = support::test_guard().await;
+    let (a, b, _a_id, b_id) = connected_pair().await;
+
+    // `shutdown()` takes ownership of `self`, so clone before calling it.
+    // The clone shares the same Arc-wrapped inner endpoint, meaning the
+    // cancelled CancellationToken is visible on `b_drainer` after shutdown.
+    let b_drainer = b.clone();
+
+    // Number of app-stream handles to queue. See doc comment for the regression
+    // guard math.
+    const DRAIN_STREAMS: usize = 8;
+
+    // All streams (primer + test batch) are kept alive until after the drain
+    // assertions. This prevents `SendStream::drop()` from scheduling an
+    // implicit `finish()` before `b`'s reader task has had a chance to read
+    // the 8-byte stream magic.
+    let mut a_streams: Vec<_> = Vec::with_capacity(DRAIN_STREAMS + 1);
+
+    // Primer: open one stream and block until `b.accept_bi()` returns it.
+    // This is a hard synchronisation point: if it returns, then both
+    // `b.accept()` has run (reader task spawned) and the QUIC path from `a`
+    // to `b`'s `app_bi_tx` channel is confirmed live. Any subsequent stream
+    // opened by `a` will follow the same path.
+    a_streams.push(a.open_bi(&b_id).await.expect("primer open_bi"));
+    timeout(Duration::from_secs(5), b.accept_bi())
+        .await
+        .expect("primer timed out — b.accept() may not have run")
+        .expect("primer accept_bi error");
+
+    // With the reader task confirmed active, open DRAIN_STREAMS more streams.
+    // Each `open_bi` call writes the 8-byte magic prefix via `write_all` and
+    // returns synchronously once the bytes are in Quinn's send buffer. The
+    // reader task processes each stream independently (accept_bi + read_exact
+    // + try_send) in its own loop iterations.
+    for _ in 0..DRAIN_STREAMS {
+        a_streams.push(a.open_bi(&b_id).await.expect("open_bi"));
+    }
+
+    // Give `b`'s reader task time to forward all DRAIN_STREAMS handles into
+    // `app_bi_tx`. The primer confirmed the reader task is active; on loopback
+    // the forwarding is O(µs). 100 ms is a very conservative bound even under
+    // concurrent test load.
+    sleep(Duration::from_millis(100)).await;
+
+    // Trigger shutdown. This cancels the CancellationToken shared by `b` and
+    // `b_drainer`. Now, for the first DRAIN_STREAMS calls to `accept_bi`, both
+    // the queue arm and the shutdown arm of the internal select are
+    // simultaneously ready.
+    b.shutdown().await;
+
+    // All DRAIN_STREAMS handles must come back as `Ok` before `ShuttingDown`.
+    // With `biased;`, the queue arm is always polled first, so the drain is
+    // deterministic and immediate. Without `biased;`, each call is a coin-flip
+    // and this loop fails on ~99.6% of runs.
+    for i in 0..DRAIN_STREAMS {
+        match b_drainer.accept_bi().await {
+            Ok(_) => {}
+            Err(e) => panic!(
+                "accept_bi[{i}] returned {e:?} before the queue was drained; \
+                 regression: `biased;` may be missing from the internal select"
+            ),
+        }
+    }
+
+    // With the queue empty and shutdown cancelled, the shutdown arm must fire
+    // on the very next call. (`rx.recv()` is not ready when the queue is empty,
+    // so `biased;` order makes no difference here — the shutdown arm wins.)
+    match b_drainer.accept_bi().await {
+        Err(NodeError::Endpoint(EndpointError::ShuttingDown)) => {}
+        other => panic!("expected ShuttingDown after full drain, got {other:?}"),
+    }
+
+    // Drop here so streams stay alive through all assertions above.
+    drop(a_streams);
 }


### PR DESCRIPTION
## Summary

- Adds `accept_bi_drains_queue_before_shutting_down` in `tests/node_app_streams.rs`, pinning the contract that `accept_bi` drains every handle in `app_bi_tx` before the `ShuttingDown` arm can fire.
- The `biased;` keyword in `P2pEndpoint::accept_bi`'s `tokio::select!` is what enforces this ordering; without it each call is a 50/50 coin-flip — with N=8 queued handles the regression is caught on ~99.6% of runs.
- Adds `.config/nextest.toml` with `node-app-streams` test-group (`max-threads = 1`) to serialise `node_app_streams` tests, matching the original intent of `test_guard()` in `tests/support/mod.rs` which is a no-op across nextest's process-per-test model.

## Regression guard

| Scenario | Result |
|----------|--------|
| `biased;` present (correct) | All 8 handles return `Ok` before `ShuttingDown` |
| `biased;` removed (regression) | `ShuttingDown` fires mid-drain with probability ≈ 99.6% per run |

## Test design

- **Primer stream**: one stream is opened and confirmed via `b.accept_bi()` before the 8-stream drain batch. This is a hard sync point proving `b.accept()` has run and the QUIC→reader-task→`app_bi_tx` path is live.
- **Keep-alive**: `(SendStream, RecvStream)` pairs are kept alive until after all assertions to prevent `SendStream::drop()` from racing with the 8-byte magic-prefix read in the reader task.
- **Nextest config**: `b.shutdown()` sends QUIC Connection Close to all active connections, including any mDNS-discovered cross-test-process connections. Serialising the binary prevents that from interfering with concurrent echo tests.

## Test plan

- [x] `cargo nextest run --test node_app_streams -E 'not test(node_open_bi_accept_bi_smoke)'` passes 15/15 times
- [x] `cargo clippy --all-features --all-targets` (RUSTFLAGS="-D warnings") — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Removed `biased;` manually and confirmed the test fails reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a regression test (`accept_bi_drains_queue_before_shutting_down`) that pins the contract that `P2pEndpoint::accept_bi`'s `biased;` select drains every queued handle from `app_bi_tx` before the `ShuttingDown` arm can fire, and adds a nextest config to serialize the `node_app_streams` test binary so that `b.shutdown()`'s QUIC Connection Close frames cannot interfere with concurrent echo tests.

- **Regression guard**: 8 streams are queued and confirmed drained before `ShuttingDown` is returned; without `biased;` this sequence fails on ~99.6% of runs, making the guard highly reliable.
- **Primer sync**: one stream is opened and confirmed via `b.accept_bi()` before the batch, ensuring the reader task and QUIC path are live — a concrete sync point rather than a sleep.
- **Nextest serialization**: `.config/nextest.toml` assigns `binary_id(ant-quic::node_app_streams)` to a `max-threads = 1` group, correctly replacing the no-op in-process `test_guard()` mutex for nextest's process-per-test model.

<h3>Confidence Score: 4/5</h3>

Safe to merge — changes are test-only with no production code touched; the nextest config correctly serializes the affected binary.

The regression guard is well-reasoned and the primer sync gives a concrete proof that the reader task is active before the batch is queued. The one weakness is that the 100 ms sleep between opening the 8 streams and calling b.shutdown() is the only mechanism ensuring all 8 handles are in app_bi_tx at shutdown time. Under sustained CI load, if the reader task lags past 100 ms, the test can fail for reasons unrelated to the biased; regression being guarded, making failures harder to triage.

tests/node_app_streams.rs — specifically the 100 ms sleep before b.shutdown()

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .config/nextest.toml | New nextest config serializing all `node_app_streams` tests to 1 thread via a named test-group; filter and group syntax are correct for the `ant-quic` package. |
| tests/node_app_streams.rs | Adds `accept_bi_drains_queue_before_shutting_down` regression test; logic, primer sync, and `biased;` guard math are correct, but the 100 ms sleep that populates `app_bi_tx` before shutdown is a time-based sync point that could misfire under heavy load. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant a as Node a
    participant b as Node b reader task
    participant q as app_bi_tx queue
    participant d as b_drainer

    Note over a,d: Primer sync
    a->>b: open_bi primer
    b->>q: try_send handle
    d->>q: accept_bi returns Ok primer

    Note over a,d: Drain batch
    a->>b: open_bi x8
    b->>q: try_send handle x8
    Note over a,d: sleep 100ms to wait for all 8 in queue

    Note over a,d: Shutdown
    a->>b: b.shutdown cancels CancellationToken

    Note over d,q: Both queue arm AND shutdown arm ready simultaneously
    loop "DRAIN_STREAMS = 8"
        d->>q: accept_bi biased polls queue first
        q-->>d: Ok stream
    end

    d->>q: accept_bi queue empty shutdown arm fires
    q-->>d: Err ShuttingDown
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant a as Node a
    participant b as Node b reader task
    participant q as app_bi_tx queue
    participant d as b_drainer

    Note over a,d: Primer sync
    a->>b: open_bi primer
    b->>q: try_send handle
    d->>q: accept_bi returns Ok primer

    Note over a,d: Drain batch
    a->>b: open_bi x8
    b->>q: try_send handle x8
    Note over a,d: sleep 100ms to wait for all 8 in queue

    Note over a,d: Shutdown
    a->>b: b.shutdown cancels CancellationToken

    Note over d,q: Both queue arm AND shutdown arm ready simultaneously
    loop "DRAIN_STREAMS = 8"
        d->>q: accept_bi biased polls queue first
        q-->>d: Ok stream
    end

    d->>q: accept_bi queue empty shutdown arm fires
    q-->>d: Err ShuttingDown
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/node_app_streams.rs:391-395
**Time-based sync before shutdown may be flaky under load**

The 100 ms sleep is the only guarantee that all `DRAIN_STREAMS` handles are inside `app_bi_tx` before `b.shutdown()` cancels the token. On a heavily loaded runner, the reader task's "accept + read 8 bytes + `try_send`" loop could lag behind, leaving some handles unforwarded at the moment shutdown fires. If even one handle is missing from the queue, the assertion in the drain loop will fail — not because `biased;` is absent, but because the queue was never fully populated, making the failure indistinguishable from a regression without careful log inspection.

A condition-based spin (e.g., polling a counter incremented by each `try_send`) or a small rendezvous channel fed by the reader task would eliminate this race entirely. As-is, the 100 ms bound works reliably on loopback, but its correctness is implicit rather than proven.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(node): drain-on-shutdown regression..."](https://github.com/saorsa-labs/ant-quic/commit/8d6d926d2d01c4a43c874882fb7e9b7fd06c97da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42134450)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->