### PR TITLE
fix(connection): close last unchecked time subtraction + boot-epoch regression test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ant-quic"
-version = "0.27.28"
+version = "0.27.29"
 dependencies = [
  "ant-quic-workspace-hack",
  "anyhow",

--- a/src/connection/paths.rs
+++ b/src/connection/paths.rs
@@ -384,7 +384,9 @@ impl RttEstimator {
         // Based on RFC6298.
         if let Some(smoothed) = self.smoothed {
             let adjusted_rtt = if self.min + ack_delay <= self.latest {
-                self.latest - ack_delay
+                // `saturating_sub` is panic-free; the guard above guarantees
+                // `ack_delay <= self.latest` so this never saturates. x0x #190.
+                self.latest.saturating_sub(ack_delay)
             } else {
                 self.latest
             };

--- a/src/crypto/certificate_negotiation.rs
+++ b/src/crypto/certificate_negotiation.rs
@@ -628,4 +628,64 @@ mod tests {
         let stats = manager.get_stats();
         assert_eq!(stats.timed_out, 1);
     }
+    /// Regression for saorsa-labs/x0x#190: `Instant - Duration` panics at low uptime.
+    ///
+    /// `Instant`'s epoch is *boot* on Windows (QPC) and near process-start on
+    /// other platforms, so `Instant::now() - max_age` underflows — panicking
+    /// with "overflow when subtracting duration from instant" — whenever
+    /// `max_age` exceeds the process uptime. A daemon auto-started shortly
+    /// after boot therefore panicked on every cleanup pass whose window was
+    /// longer than its uptime.
+    ///
+    /// `cleanup_old_sessions` now evaluates `now.saturating_duration_since(t)
+    /// < max_age`, which is panic-free and answers "nothing is stale" when
+    /// `max_age > uptime` — the correct result, since nothing can be older than
+    /// a window longer than the process has existed. This test feeds a 100-year
+    /// window (guaranteed larger than any host uptime); the old `Instant::now()
+    /// - max_age` subtraction would have panicked here.
+    #[test]
+    fn cleanup_old_sessions_survives_window_longer_than_uptime() {
+        let manager = CertificateNegotiationManager::default();
+        let now = Instant::now();
+        {
+            let mut sessions = manager.sessions.write();
+            sessions.insert(
+                NegotiationId::new(),
+                NegotiationState::Completed {
+                    result: NegotiationResult::new(
+                        CertificateType::RawPublicKey,
+                        CertificateType::X509,
+                    ),
+                    completed_at: now,
+                },
+            );
+            sessions.insert(
+                NegotiationId::new(),
+                NegotiationState::Failed {
+                    error: "synthetic".to_string(),
+                    failed_at: now,
+                },
+            );
+            sessions.insert(
+                NegotiationId::new(),
+                NegotiationState::TimedOut { timeout_at: now },
+            );
+        }
+        assert_eq!(manager.sessions.read().len(), 3);
+
+        // A window longer than any conceivable uptime. Under the old code this
+        // formed `Instant::now() - max_age` and panicked; the saturating
+        // rewrite correctly concludes nothing is stale.
+        let impossible_age = Duration::from_secs(86_400 * 365 * 100);
+        manager.cleanup_old_sessions(impossible_age);
+        assert_eq!(
+            manager.sessions.read().len(),
+            3,
+            "nothing evicted when max_age exceeds process uptime"
+        );
+
+        // Correctness preserved: a zero-age window evicts every terminal session.
+        manager.cleanup_old_sessions(Duration::ZERO);
+        assert_eq!(manager.sessions.read().len(), 0);
+    }
 }


### PR DESCRIPTION
## Summary

Completes the panic-free time-math sweep for [saorsa-labs/x0x#190](https://github.com/saorsa-labs/x0x/issues/190) in ant-quic.

The five original `Instant - Duration` panic sites were fixed in `76aa3cb` (shipped in v0.27.29). This PR closes the **one remaining production site** that `clippy::unchecked_time_subtraction` still flagged, and adds the **regression test** that was missing from the original fix.

## Background — why `Instant - Duration` panics

`std::time::Instant`'s epoch is **boot** on Windows (QPC) and near process-start on other platforms. The `Sub<Duration>` impl calls `.expect("overflow when subtracting duration from instant")`, so `Instant::now() - duration` **panics** whenever `duration > time_since_boot`. A daemon auto-started ~15–20 s after boot therefore panics on every cleanup/loss-detection window longer than its uptime.

The fix everywhere: replace `Instant - Duration` with `Instant.saturating_duration_since(Instant)` (an `Instant - Instant` subtraction that saturates to zero, panic-free since Rust 1.60), which is the algebraic equivalent because all stored timestamps are `<= now`.

## Changes

### `src/connection/paths.rs` — `RttEstimator::update` (new)
`self.latest - ack_delay` was a `Duration - Duration` subtraction (also panics on underflow, same lint family). The pre-existing guard `self.min + ack_delay <= self.latest` already guarantees `ack_delay <= self.latest`, so switching to `self.latest.saturating_sub(ack_delay)` is **provably identical** — the saturating branch is unreachable — just panic-free and lint-clean.

### `src/crypto/certificate_negotiation.rs` — regression test
Adds `cleanup_old_sessions_survives_window_longer_than_uptime`. It feeds `cleanup_old_sessions` a **100-year** `max_age` (guaranteed larger than any host uptime). Under the old code this evaluated `Instant::now() - max_age` and panicked; the saturating rewrite correctly concludes *nothing is stale* (nothing can be older than a window longer than the process has existed). Also asserts a zero-age window still evicts terminal sessions, proving cleanup behaviour is preserved.

### `Cargo.lock`
Aligns ant-quic to `0.27.29` (the release commit bumped `Cargo.toml` only; cargo regenerated the lockfile).

## Verification

```
cargo fmt --all                                                    # clean
cargo clippy --all-features --all-targets -- -D warnings           # clean
cargo clippy --all-features --lib -- -D warnings \
       -W clippy::unchecked_time_subtraction                        # production code clean
cargo check --all-targets --all-features                            # clean
cargo test --lib --all-features certificate_negotiation::           # 6 passed
cargo test --lib --all-features rtt / paths::                       # 28 passed
```

The five previously-fixed sites remain correct:
- `connection/mod.rs` loss detection — `now.saturating_duration_since(info.time_sent) >= loss_delay` (quinn #2436 pattern)
- `connection/nat_traversal.rs` rate/coordination trackers — `now.saturating_duration_since(entry) > rate_window`
- `connection/nat_traversal.rs` `NetworkConditionMonitor::cleanup` — dead `_cutoff_time` removed
- `crypto/certificate_negotiation.rs` `cleanup_old_sessions` — `now.saturating_duration_since(field) < max_age`

Refs saorsa-labs/x0x#190

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the last `clippy::unchecked_time_subtraction` site in production code and adds the regression test that was missing from the original five-site fix. The changes are minimal and targeted.

- **`src/connection/paths.rs`**: `RttEstimator::update` switches `self.latest - ack_delay` (`Duration - Duration`) to `self.latest.saturating_sub(ack_delay)`; the existing guard `self.min + ack_delay <= self.latest` guarantees the saturating branch is never taken, so runtime behaviour is identical but the panic path is removed.
- **`src/crypto/certificate_negotiation.rs`**: Adds `cleanup_old_sessions_survives_window_longer_than_uptime`, a regression test that drives `cleanup_old_sessions` with a 100-year window (larger than any process uptime, which previously caused a panic via `Instant::now() - max_age`) and a zero-age window (verifying full eviction of all terminal states).
- **`Cargo.lock`**: Lockfile regenerated to match the `0.27.29` version already in `Cargo.toml`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the production code changes are a straight swap to panic-free equivalents with no observable behaviour difference, and the new regression test correctly exercises both the preserved-data and full-eviction paths.

Both code changes are trivially correct: the saturating_sub in RttEstimator::update is unreachable due to the pre-existing guard, and the cleanup_old_sessions fix was already in place — this PR only adds its missing test. The regression test covers the critical edge cases for all three terminal session states.

No files require special attention; the only note is a missing blank line between test functions in certificate_negotiation.rs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/connection/paths.rs | Replaces Duration - Duration subtraction with saturating_sub in RttEstimator::update; the pre-existing guard makes the saturating branch unreachable, so behaviour is unchanged |
| src/crypto/certificate_negotiation.rs | Adds cleanup_old_sessions_survives_window_longer_than_uptime regression test covering both the impossible-age (no evictions) and zero-age (full eviction) paths; logic is correct for all three terminal states |
| Cargo.lock | Version bump from 0.27.28 to 0.27.29 to align the lockfile with the Cargo.toml change shipped in the previous commit |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["RttEstimator::update(ack_delay, rtt)"] --> B["self.latest = rtt\nself.min = min(self.min, latest)"]
    B --> C{self.min + ack_delay <= self.latest?}
    C -- "Yes" --> D["self.latest.saturating_sub(ack_delay)"]
    C -- "No" --> E["adjusted_rtt = self.latest"]
    D --> F["Update EWMA smoothed + var"]
    E --> F
    G["cleanup_old_sessions(max_age)"] --> H["now = Instant::now()"]
    H --> I{For each terminal session}
    I -- "Completed / Failed / TimedOut" --> J["now.saturating_duration_since(ts) < max_age?"]
    J -- true --> K["Retain"]
    J -- false --> L["Evict"]
    I -- "Pending / Waiting" --> M["Always retain"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["RttEstimator::update(ack_delay, rtt)"] --> B["self.latest = rtt\nself.min = min(self.min, latest)"]
    B --> C{self.min + ack_delay <= self.latest?}
    C -- "Yes" --> D["self.latest.saturating_sub(ack_delay)"]
    C -- "No" --> E["adjusted_rtt = self.latest"]
    D --> F["Update EWMA smoothed + var"]
    E --> F
    G["cleanup_old_sessions(max_age)"] --> H["now = Instant::now()"]
    H --> I{For each terminal session}
    I -- "Completed / Failed / TimedOut" --> J["now.saturating_duration_since(ts) < max_age?"]
    J -- true --> K["Retain"]
    J -- false --> L["Evict"]
    I -- "Pending / Waiting" --> M["Always retain"]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/crypto/certificate_negotiation.rs:628-631
Missing blank line before the new test function. All other test functions in this module are separated by a blank line; this one runs directly after the closing `}` of `test_negotiation_timeout_handling`, which makes the boundary harder to see at a glance.

```suggestion
        let stats = manager.get_stats();
        assert_eq!(stats.timed_out, 1);
    }

    /// Regression for saorsa-labs/x0x#190: `Instant - Duration` panics at low uptime.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(connection): close last unchecked ti..."](https://github.com/saorsa-labs/ant-quic/commit/62c0a50f0de5b891af77e3f6ecda8475d76e5bd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42961078)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->