### PR TITLE
chore(release): v0.27.30 — complete x0x#190 fix + Security-gate advisory bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ant-quic"
-version = "0.27.29"
+version = "0.27.30"
 dependencies = [
  "ant-quic-workspace-hack",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "ant-quic"
-version = "0.27.29"
+version = "0.27.30"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
0.27.29 was tagged and published (2026-07-07) from `c3ade267`, which predates #207 — so the published 0.27.29 lacks the final `certificate_negotiation.rs` sweep, the `paths.rs` RttEstimator fix, and the crossbeam-epoch RUSTSEC-2026-0204 bump. v0.27.30 ships the complete fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cuts the v0.27.30 patch release, bumping the version in `Cargo.toml` and `Cargo.lock` from 0.27.29 to 0.27.30. The actual fixes it ships — the `certificate_negotiation.rs` sweep, the `paths.rs` `RttEstimator` underflow fix, and the `crossbeam-epoch` upgrade from 0.9.18 to 0.9.20 (RUSTSEC-2026-0204) — were all landed on `master` in commit #207 (`e9e96ba`), which is the base of this PR.

- **Version bump only**: the diff is two one-line changes (package version in `Cargo.toml` and the corresponding `ant-quic` entry in `Cargo.lock`). All substantive code changes are already in the base branch.
- **Security advisory resolved**: `crossbeam-epoch` is already pinned to 0.9.20 in `Cargo.lock`, which is the patched range (`>=0.9.20`) for RUSTSEC-2026-0204 (invalid pointer dereference in `fmt::Pointer` for `Atomic`/`Shared`). The published 0.27.29 crate (from tag `c3ade267`) still carries 0.9.18, so this release is needed to ship the remediation.
- **Semver**: incrementing the patch component for a security-fix + bug-fix release is correct.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only changes are the package version string in Cargo.toml and the matching ant-quic entry in Cargo.lock.

The diff is two one-line version-string changes. All substantive code changes (security-advisory lockfile bump, connection-timing fixes) arrived on master via PR #207 and are already confirmed correct in the base commit. There is nothing new to break here.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Version bumped from 0.27.29 to 0.27.30; no other changes |
| Cargo.lock | Lock file updated to reflect ant-quic 0.27.30; crossbeam-epoch already at patched 0.9.20 (carried in from base commit #207) |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["c3ade267 — v0.27.29 tag\ncrossbeam-epoch 0.9.18\n(RUSTSEC-2026-0204 ⚠️)"] --> B["e9e96ba — PR #207 merged to master\n• certificate_negotiation.rs sweep\n• paths.rs RttEstimator fix\n• crossbeam-epoch 0.9.18 → 0.9.20 ✅"]
    B --> C["0613da76 — this PR #208\nCargo.toml / Cargo.lock: 0.27.29 → 0.27.30"]
    C --> D["Published crate v0.27.30\nAll fixes included\ncrossbeam-epoch 0.9.20 ✅"]

    style A fill:#ffdddd,stroke:#cc0000
    style B fill:#fff3cd,stroke:#856404
    style C fill:#d4edda,stroke:#155724
    style D fill:#d4edda,stroke:#155724
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["c3ade267 — v0.27.29 tag\ncrossbeam-epoch 0.9.18\n(RUSTSEC-2026-0204 ⚠️)"] --> B["e9e96ba — PR #207 merged to master\n• certificate_negotiation.rs sweep\n• paths.rs RttEstimator fix\n• crossbeam-epoch 0.9.18 → 0.9.20 ✅"]
    B --> C["0613da76 — this PR #208\nCargo.toml / Cargo.lock: 0.27.29 → 0.27.30"]
    C --> D["Published crate v0.27.30\nAll fixes included\ncrossbeam-epoch 0.9.20 ✅"]

    style A fill:#ffdddd,stroke:#cc0000
    style B fill:#fff3cd,stroke:#856404
    style C fill:#d4edda,stroke:#155724
    style D fill:#d4edda,stroke:#155724
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump version to v0.27.30..."](https://github.com/saorsa-labs/ant-quic/commit/0613da76ef40b2bc402d21d61c63c3797181c390) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42965717)</sub>

<!-- /greptile_comment -->