### PR TITLE
fix(connection): stop InFlight underflow — abandoned paths' packets debited from surviving paths (#230)

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1696,7 +1696,12 @@ impl Connection {
                 Timer::PathValidation => {
                     debug!("path validation failed");
                     if let Some((_, prev)) = self.prev_path.take() {
+                        // The path we're abandoning owns in-flight packets whose accounting is
+                        // dropped along with it. Restart the restored path's window so those
+                        // packets can never be debited from it when they are later acked or
+                        // declared lost (x0x #230).
                         self.path = prev;
+                        self.path.restart_in_flight();
                     }
                     self.path.challenge = None;
                     self.path.challenge_pending = false;

--- a/src/connection/paths.rs
+++ b/src/connection/paths.rs
@@ -219,7 +219,19 @@ impl PathData {
         if self.first_packet.is_none() {
             self.first_packet = Some(pn);
         }
-        self.in_flight.bytes -= space.sent(pn, packet);
+        // `PacketSpace::sent` returns the byte count of any forgotten non-ack-eliciting tail
+        // packet evicted from the space to bound memory. Those bytes may have been sent on a
+        // *different* path (before a migration), so they were never counted in this path's
+        // `in_flight.bytes`. Subtracting them raw would underflow; use `saturating_sub` so a
+        // cross-path eviction produces a bounded accounting error (counter clamps at 0) rather
+        // than wrapping to ~2^64 and stalling congestion control permanently in release builds.
+        let forgotten_bytes = space.sent(pn, packet);
+        debug_assert!(
+            self.in_flight.bytes >= forgotten_bytes,
+            "InFlight::bytes underflow in PathData::sent: forgotten non-ack-eliciting tail \
+             bytes may belong to a previous path"
+        );
+        self.in_flight.bytes = self.in_flight.bytes.saturating_sub(forgotten_bytes);
     }
 
     /// Remove `packet` with number `pn` from this path's congestion control counters, or return
@@ -499,8 +511,21 @@ impl InFlight {
 
     /// Update counters to account for a packet becoming acknowledged, lost, or abandoned
     fn remove(&mut self, packet: &SentPacket) {
-        self.bytes -= u64::from(packet.size);
-        self.ack_eliciting -= u64::from(packet.ack_eliciting);
+        debug_assert!(
+            self.bytes >= u64::from(packet.size),
+            "InFlight::bytes underflow: removing packet never counted or already removed"
+        );
+        debug_assert!(
+            self.ack_eliciting >= u64::from(packet.ack_eliciting),
+            "InFlight::ack_eliciting underflow: removing packet never counted or already removed"
+        );
+        // `saturating_sub` bounds the accounting error to zero instead of wrapping to ~2^64 in
+        // release builds (where the debug_asserts above are elided). A root cause fix for the
+        // double-remove that triggers these is tracked separately (x0x #230).
+        self.bytes = self.bytes.saturating_sub(u64::from(packet.size));
+        self.ack_eliciting = self
+            .ack_eliciting
+            .saturating_sub(u64::from(packet.ack_eliciting));
     }
 }
 
@@ -992,5 +1017,99 @@ mod tests {
         // Rate should be preserved, tokens should be reset
         assert_eq!(path.observation_rate_limiter.rate, 15.0);
         assert_eq!(path.observation_rate_limiter.tokens, 15.0); // Full tokens after reset
+    }
+}
+
+#[cfg(test)]
+mod in_flight_tests {
+    use super::*;
+
+    /// Construct a minimal `SentPacket` for testing `InFlight` counters.
+    ///
+    /// `SentPacket` is private to the `connection` module; constructing it here is
+    /// acceptable because this test module is also inside that module tree.
+    fn make_packet(size: u16, ack_eliciting: bool) -> SentPacket {
+        SentPacket {
+            time_sent: Instant::now(),
+            size,
+            ack_eliciting,
+            largest_acked: None,
+            retransmits: Default::default(),
+            stream_frames: Default::default(),
+        }
+    }
+
+    /// A single insert followed by a single remove must bring both counters back to zero.
+    #[test]
+    fn in_flight_insert_remove_balances() {
+        let mut in_flight = InFlight::new();
+        let packet = make_packet(1200, true);
+
+        in_flight.insert(&packet);
+        assert_eq!(in_flight.bytes, 1200);
+        assert_eq!(in_flight.ack_eliciting, 1);
+
+        in_flight.remove(&packet);
+        assert_eq!(
+            in_flight.bytes, 0,
+            "bytes must return to zero after balanced remove"
+        );
+        assert_eq!(
+            in_flight.ack_eliciting, 0,
+            "ack_eliciting must return to zero after balanced remove"
+        );
+    }
+
+    /// A non-ack-eliciting packet (e.g. pure PADDING) counts bytes but not ack_eliciting.
+    #[test]
+    fn in_flight_non_ack_eliciting_packet() {
+        let mut in_flight = InFlight::new();
+        let packet = make_packet(64, false);
+
+        in_flight.insert(&packet);
+        assert_eq!(in_flight.bytes, 64);
+        assert_eq!(in_flight.ack_eliciting, 0);
+
+        in_flight.remove(&packet);
+        assert_eq!(in_flight.bytes, 0);
+        assert_eq!(in_flight.ack_eliciting, 0);
+    }
+
+    /// In debug builds a double-remove must trip the `debug_assert!` with a message
+    /// containing "underflow", making the bug immediately visible rather than silently
+    /// wrapping to ~2^64.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "underflow")]
+    fn in_flight_double_remove_panics_in_debug() {
+        let mut in_flight = InFlight::new();
+        let packet = make_packet(1200, true);
+
+        in_flight.insert(&packet);
+        in_flight.remove(&packet); // first remove — OK
+        in_flight.remove(&packet); // double-remove — must panic
+    }
+
+    /// In release builds (no debug assertions) a double-remove must clamp both counters
+    /// at 0 via `saturating_sub` instead of wrapping to ~2^64 and freezing congestion
+    /// control. This is the fix for x0x #230.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn in_flight_double_remove_saturates_in_release() {
+        let mut in_flight = InFlight::new();
+        let packet = make_packet(1200, true);
+
+        in_flight.insert(&packet);
+        in_flight.remove(&packet); // first remove — OK
+        in_flight.remove(&packet); // double-remove — must clamp, not wrap
+
+        assert_eq!(
+            in_flight.bytes, 0,
+            "bytes must saturate at 0 on double-remove, not wrap to ~2^64"
+        );
+        assert_eq!(
+            in_flight.ack_eliciting, 0,
+            "ack_eliciting must saturate at 0 on double-remove, not wrap"
+        );
     }
 }

--- a/src/connection/paths.rs
+++ b/src/connection/paths.rs
@@ -49,9 +49,16 @@ pub(super) struct PathData {
     pub(super) in_flight: InFlight,
     /// Number of the first packet sent on this path
     ///
-    /// Used to determine whether a packet was sent on an earlier path. Insufficient to determine if
-    /// a packet was sent on a later path.
+    /// Used to determine whether a packet was sent on an earlier path.
     first_packet: Option<u64>,
+    /// Number of the most recent packet sent on this path
+    ///
+    /// Used together with `first_packet` to determine whether a packet was sent on a *later* path.
+    /// `first_packet` alone is not sufficient: paths can be abandoned (see `Connection::migrate` and
+    /// the `PathValidation` timeout) while packets sent on them are still in flight, and without an
+    /// upper bound those packets would be wrongly debited from an older surviving path, underflowing
+    /// its in-flight counters (x0x #230).
+    last_packet: Option<u64>,
 
     /// Snapshot of the qlog recovery metrics
     #[cfg(feature = "__qlog")]
@@ -110,6 +117,7 @@ impl PathData {
             first_packet_after_rtt_sample: None,
             in_flight: InFlight::new(),
             first_packet: None,
+            last_packet: None,
             #[cfg(feature = "__qlog")]
             congestion_metrics: CongestionMetrics::default(),
             address_info: PathAddressInfo::new(),
@@ -135,6 +143,7 @@ impl PathData {
             first_packet_after_rtt_sample: prev.first_packet_after_rtt_sample,
             in_flight: InFlight::new(),
             first_packet: None,
+            last_packet: None,
             #[cfg(feature = "__qlog")]
             congestion_metrics: prev.congestion_metrics.clone(),
             address_info: PathAddressInfo::new(), // Reset for new path
@@ -219,17 +228,38 @@ impl PathData {
         if self.first_packet.is_none() {
             self.first_packet = Some(pn);
         }
+        // Packet numbers are not globally monotonic (they are per-space, and spaces are interleaved
+        // during the handshake), so take the maximum to keep this a true upper bound.
+        self.last_packet = Some(self.last_packet.map_or(pn, |last| cmp::max(last, pn)));
         self.in_flight.bytes -= space.sent(pn, packet);
     }
 
     /// Remove `packet` with number `pn` from this path's congestion control counters, or return
-    /// `false` if `pn` was sent before this path was established.
+    /// `false` if `pn` was not sent on this path.
     pub(super) fn remove_in_flight(&mut self, pn: u64, packet: &SentPacket) -> bool {
         if self.first_packet.is_none_or(|first| first > pn) {
             return false;
         }
+        // `pn` may have been sent on a *later* path which has since been abandoned, in which case
+        // its bytes were never inserted into this path's counters and must not be removed from them.
+        if self.last_packet.is_none_or(|last| last < pn) {
+            return false;
+        }
         self.in_flight.remove(packet);
         true
+    }
+
+    /// Forget every packet previously attributed to this path
+    ///
+    /// Used when a path is restored after the path that superseded it is abandoned. The abandoned
+    /// path's in-flight accounting dies with it, and the restored path's own accounting is stale by
+    /// at least three PTOs, so the only consistent state is a clean slate: without this, packets
+    /// sent on the abandoned path fall inside the restored path's packet-number window once it
+    /// resumes sending, and would be debited from counters that never held them.
+    pub(super) fn restart_in_flight(&mut self) {
+        self.in_flight = InFlight::new();
+        self.first_packet = None;
+        self.last_packet = None;
     }
 
     #[cfg(feature = "__qlog")]
@@ -615,6 +645,7 @@ impl PathAddressInfo {
 
 #[cfg(test)]
 mod tests {
+    use super::super::spaces::ThinRetransmits;
     use super::*;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -992,5 +1023,110 @@ mod tests {
         // Rate should be preserved, tokens should be reset
         assert_eq!(path.observation_rate_limiter.rate, 15.0);
         assert_eq!(path.observation_rate_limiter.tokens, 15.0); // Full tokens after reset
+    }
+
+    /// A minimal ack-eliciting packet for in-flight accounting tests
+    fn sent_packet(size: u16, now: Instant) -> SentPacket {
+        SentPacket {
+            time_sent: now,
+            size,
+            ack_eliciting: true,
+            largest_acked: None,
+            retransmits: ThinRetransmits::default(),
+            stream_frames: Default::default(),
+        }
+    }
+
+    /// x0x #230: a second migration started before the first has validated drops the intermediate
+    /// path (`Connection::migrate`'s `if prev.challenge.is_none()` guard keeps the *older* path as
+    /// `prev_path`). Packets the intermediate path sent are still in `sent_packets`, and when they
+    /// are acked or declared lost `Connection::remove_in_flight` walks `[current, prev]`. The older
+    /// path must not claim them: their bytes were never inserted into its counters, so debiting
+    /// them underflows `InFlight::bytes` — a panic in debug builds and a permanently stalled
+    /// congestion window in release builds.
+    #[test]
+    fn abandoned_intermediate_path_packets_are_not_debited_from_older_path() {
+        let config = TransportConfig::default();
+        let now = Instant::now();
+        let remote1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 8080);
+        let remote2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2)), 8080);
+        let remote3 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 3)), 8080);
+        let mut space = PacketSpace::new(now);
+
+        // Original path sends two packets.
+        let mut original = PathData::new(remote1, false, None, now, &config);
+        original.sent(0, sent_packet(1200, now), &mut space);
+        original.sent(1, sent_packet(1200, now), &mut space);
+        assert_eq!(original.in_flight.bytes, 2400);
+
+        // First migration: the intermediate path becomes current and sends two more packets.
+        let mut intermediate = PathData::from_previous(remote2, &original, now);
+        intermediate.sent(2, sent_packet(1200, now), &mut space);
+        intermediate.sent(3, sent_packet(1200, now), &mut space);
+
+        // Second migration before the first validated: `current` becomes the new path, `original`
+        // is retained as `prev_path`, and `intermediate` is dropped with its counters.
+        let mut current = PathData::from_previous(remote3, &intermediate, now);
+        current.sent(4, sent_packet(1200, now), &mut space);
+        drop(intermediate);
+
+        // The original path's own packets are acked, emptying its counters.
+        assert!(original.remove_in_flight(0, &sent_packet(1200, now)));
+        assert!(original.remove_in_flight(1, &sent_packet(1200, now)));
+        assert_eq!(original.in_flight.bytes, 0);
+        assert_eq!(original.in_flight.ack_eliciting, 0);
+
+        // An ack for a packet sent on the abandoned intermediate path must be claimed by neither
+        // surviving path. Before the fix, `original` claimed it and underflowed.
+        assert!(!current.remove_in_flight(3, &sent_packet(1200, now)));
+        assert!(!original.remove_in_flight(3, &sent_packet(1200, now)));
+        assert_eq!(original.in_flight.bytes, 0);
+        assert_eq!(original.in_flight.ack_eliciting, 0);
+
+        // The current path still accounts for its own packets.
+        assert!(current.remove_in_flight(4, &sent_packet(1200, now)));
+        assert_eq!(current.in_flight.bytes, 0);
+    }
+
+    /// x0x #230: when path validation times out the connection restores `prev_path` and drops the
+    /// unvalidated path, which by then carries all of the connection's in-flight application data.
+    /// Once the restored path resumes sending, the abandoned path's packet numbers fall inside its
+    /// window, so the packet-number range check alone cannot exclude them; the restored path's
+    /// accounting must be restarted instead.
+    #[test]
+    fn restored_path_forgets_accounting_after_validation_failure() {
+        let config = TransportConfig::default();
+        let now = Instant::now();
+        let remote1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 8080);
+        let remote2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2)), 8080);
+        let mut space = PacketSpace::new(now);
+
+        let mut original = PathData::new(remote1, false, None, now, &config);
+        original.sent(0, sent_packet(1200, now), &mut space);
+        assert!(original.remove_in_flight(0, &sent_packet(1200, now)));
+        assert_eq!(original.in_flight.bytes, 0);
+
+        // Migration: application data now flows on the unvalidated path.
+        let mut migrated = PathData::from_previous(remote2, &original, now);
+        migrated.sent(1, sent_packet(1200, now), &mut space);
+        migrated.sent(2, sent_packet(1200, now), &mut space);
+
+        // Validation times out: `migrated` is dropped and `original` is restored as the live path.
+        drop(migrated);
+        original.restart_in_flight();
+
+        // The restored path resumes sending, moving its window past the abandoned path's numbers.
+        original.sent(3, sent_packet(1200, now), &mut space);
+        assert_eq!(original.in_flight.bytes, 1200);
+
+        // Late acks for the abandoned path's packets must not be debited from the restored path.
+        assert!(!original.remove_in_flight(1, &sent_packet(1200, now)));
+        assert!(!original.remove_in_flight(2, &sent_packet(1200, now)));
+        assert_eq!(original.in_flight.bytes, 1200);
+
+        // The restored path's own packet is still accounted correctly.
+        assert!(original.remove_in_flight(3, &sent_packet(1200, now)));
+        assert_eq!(original.in_flight.bytes, 0);
+        assert_eq!(original.in_flight.ack_eliciting, 0);
     }
 }


### PR DESCRIPTION
Closes #230.

## Root cause

`Connection::remove_in_flight` attributes an acked/lost packet to a path by walking `[current, prev_path]` and picking the first path whose `first_packet <= pn` — a one-sided test with no upper bound. Two sites drop a `PathData` while its packets are still tracked in `sent_packets`:

1. **`Connection::migrate`**: a second migration before the first validates drops the intermediate path (`if prev.challenge.is_none()` keeps the *older* path as `prev_path`).
2. **`Timer::PathValidation`** (the dominant field case): validation timeout restores `prev_path` and drops the unvalidated path — which carried **all** application data for the 3×PTO validation window.

Either way, later acks/losses for the dropped path's packets get debited from a surviving path whose counters never held those bytes. `InFlight::remove` then underflows: panic at paths.rs:502 in debug builds; in release the counter wraps to ~2^64, congestion control believes ~18 EB are in flight, and the connection silently stops sending forever. ant-quic hits this where stock Quinn rarely does because NAT traversal (`migrate_to_nat_traversal_path`, fired from PATH_RESPONSE handling on both sides) makes migration flaps routine — matching the observed ~5-minute panic cadence.

## Fix

- **`PathData.last_packet`** upper bound (max across spaces): `remove_in_flight` now rejects packets outside `[first_packet, last_packet]`, so surviving paths never claim a dropped path's packets. Skipped removals under-count congestion briefly — bounded and safe.
- **`PathData::restart_in_flight()`** on the `PathValidation`-timeout restore: needed because once the restored path resumes sending, the abandoned path's packet numbers fall back *inside* its window; a clean slate is the only consistent state.
- **Defense in depth**: `InFlight::remove` and the forgotten-bytes subtraction in `PathData::sent` (which can also cross paths) now `debug_assert!` + `saturating_sub`, mirroring paths.rs:387 — release builds degrade to a bounded accounting error instead of a permanent stall.

## Verification

- Repro tests `abandoned_intermediate_path_packets_are_not_debited_from_older_path` and `restored_path_forgets_accounting_after_validation_failure` verified by mutation: removing the upper-bound check reproduces the exact field panic signature; emptying `restart_in_flight` fails the restore test.
- Hardening tests cover debug-assert on double-remove and release-mode clamping (release test run explicitly: passes).
- Hypotheses eliminated with evidence: no ack+loss double-remove (all six call sites `take` first); prev-path PATH_CHALLENGEs are untracked (`builder.finish`, not `finish_and_track`).
- Full suite: fmt, clippy `-D warnings`, 2679 lib tests, doc/quick/property, bench compile — all green. (One unrelated known `new_reno` flake observed and reran clean.)

## Known remaining (documented, out of scope)

- Forgotten-bytes cross-path attribution (paths.rs:222) is the same underflow class with a different, much rarer trigger (needs >1000-packet non-ack-eliciting tail); now clamped by the hardening but not root-fixed.
- `remove_in_flight` compares packet numbers without `SpaceId` (latent, inherited from the original Quinn fork point).
- `prev_path` never clears on successful validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents abandoned-path packets from underflowing congestion-accounting counters when they are later acknowledged or declared lost.
- Tracks both lower and upper packet-number bounds for each path.
- Resets accounting when restoring a path after validation timeout.
- Replaces wrapping subtraction with debug assertions and saturating subtraction.
- Adds regression and hardening tests for migration and double-removal scenarios.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects established in the changed code.

The new packet-range checks and accounting reset prevent abandoned-path packets from being charged to surviving paths, while saturating subtraction avoids release-mode counter wraparound.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/connection/mod.rs | Restores the previous path after validation timeout and resets its stale in-flight accounting before transmission resumes. |
| src/connection/paths.rs | Adds bounded path packet ranges, saturating counter removal, accounting restart support, and focused regression tests. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Old as Previous path
    participant New as Migrated path
    participant Conn as Connection
    participant Loss as ACK/Loss processing

    Old->>Conn: Send packets and record accounting
    Conn->>New: Migrate and start fresh accounting
    New->>Conn: Send packets within its packet range
    alt Validation succeeds
        Conn->>New: Continue on migrated path
    else Validation times out
        Conn->>Old: Restore previous path
        Conn->>Old: restart_in_flight()
    end
    Loss->>Conn: Process late packet
    Conn->>Old: Check bounded packet range
    Conn->>New: Check bounded packet range if retained
    Note over Conn: Unowned abandoned-path packet is not debited
```

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;agent/230-harden&#39; into fix..."](https://github.com/saorsa-labs/ant-quic/commit/1d55b23e591b9a26e5a1e96879bcd4133fc0940e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51166313)</sub>

<!-- /greptile_comment -->
